### PR TITLE
Config dir path customized via EVE_NICOTINE_CONFIG_DIR

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,8 @@ backward_button = 275      # Button 8
 minimize_inactive = false  # Minimize clients when cycling away (saves resources)
 ```
 
+The path to the config directory can be customized by setting the `EVE_NICOTINE_CONFIG_DIR` environment variable.
+
 ## Architecture
 
 - **Daemon mode**: Maintains window manager connection and state in memory for instant cycling

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
-use std::fs;
+use std::{env, fs};
 use std::path::PathBuf;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -58,9 +58,14 @@ fn default_minimize_inactive() -> bool {
 
 impl Config {
     fn config_dir() -> PathBuf {
-        let mut path = dirs::config_dir().unwrap_or_else(|| PathBuf::from("."));
-        path.push("nicotine");
-        path
+        match env::var("EVE_NICOTINE_CONFIG_DIR") {
+            Ok(path) => PathBuf::from(path),
+            Err(_) => {
+                let mut path = dirs::config_dir().unwrap_or_else(|| PathBuf::from("."));
+                path.push("nicotine");
+                path
+            }
+        }
     }
 
     fn config_path() -> PathBuf {


### PR DESCRIPTION
There is already an app for linux that uses `$HOME/.config/nicotine`: https://nicotine-plus.org/

So I added this environment variable to allow the config directory to be customized, so that there's a way for people like me who are running both to avoid collisions.