### PR TITLE
Refactor Windows code into pure helpers + add F16–F24 support

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,79 @@
+# Development shell for Nicotine. Provides:
+#   - Linux build deps (matches pkgs/nicotine.nix consumer)
+#   - cargo-xwin + clang + llvm so `cargo xwin clippy --target
+#     x86_64-pc-windows-msvc -- -D warnings` mirrors CI locally
+#
+# Usage: `nix-shell` (or via direnv with an `.envrc` containing
+# `use nix`). The first `cargo xwin` run downloads several hundred MB
+# of MSVC SDK + CRT into ~/.cache/cargo-xwin; subsequent runs are fast.
+#
+# This shell uses system rustup (installed via NixOS systemPackages)
+# instead of vending a fixed Rust toolchain — the project tracks stable
+# Rust and pinning it here would diverge from CI without value.
+
+{ pkgs ? import <nixpkgs> {} }:
+
+pkgs.mkShell {
+  buildInputs = with pkgs; [
+    # Linux build runtime libs — same set pkgs/nicotine.nix declares so
+    # `cargo build` (Linux target) inside this shell links cleanly.
+    pkg-config
+    xorg.libX11
+    xorg.libXcursor
+    xorg.libXrandr
+    xorg.libXi
+    xorg.libxcb
+    libxkbcommon
+    libGL
+    wayland
+
+    # Windows cross-compile via xwin. clang provides clang-cl (the MSVC-
+    # compatible front-end cargo-xwin invokes); llvm provides llvm-rc
+    # (the resource compiler build.rs calls to embed the .exe icon).
+    cargo-xwin
+    clang
+    llvm
+  ];
+
+  # Static linker hints for the Linux build path. egui-winit and the
+  # X11/Wayland deps load these at runtime; setting LD_LIBRARY_PATH so
+  # plain `cargo run` works without patchelf during dev.
+  LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath (with pkgs; [
+    libGL
+    wayland
+    libxkbcommon
+    xorg.libX11
+    xorg.libXcursor
+    xorg.libXrandr
+    xorg.libXi
+    xorg.libxcb
+  ]);
+
+  shellHook = ''
+    # Use the rustup-managed Rust toolchain, not whatever nix happens
+    # to put on PATH. The system has rustup installed via NixOS
+    # systemPackages; that toolchain is where the
+    # `x86_64-pc-windows-msvc` cross target (rust-std) gets added. A
+    # nix-store rustc/cargo on PATH would be a *different* toolchain
+    # that doesn't know about user-added targets — `cargo xwin` would
+    # then fail with `can't find crate for core`.
+    if command -v rustup >/dev/null 2>&1; then
+      rustup target add x86_64-pc-windows-msvc >/dev/null 2>&1 || true
+      RUSTUP_TOOLCHAIN_BIN="$(dirname "$(rustup which rustc 2>/dev/null)")"
+      if [ -n "$RUSTUP_TOOLCHAIN_BIN" ] && [ -d "$RUSTUP_TOOLCHAIN_BIN" ]; then
+        export PATH="$RUSTUP_TOOLCHAIN_BIN:$PATH"
+      fi
+    fi
+
+    cat <<'EOF'
+nicotine dev shell ready.
+
+Linux:    cargo build
+          cargo test
+          cargo clippy --all-targets -- -D warnings
+
+Windows:  cargo xwin clippy --release --target x86_64-pc-windows-msvc -- -D warnings
+          cargo xwin build   --release --target x86_64-pc-windows-msvc
+EOF
+  '';
+}

--- a/src/config_panel/mod.rs
+++ b/src/config_panel/mod.rs
@@ -418,6 +418,15 @@ const SUPPORTED_KEYS: &[egui::Key] = &[
     egui::Key::F13,
     egui::Key::F14,
     egui::Key::F15,
+    egui::Key::F16,
+    egui::Key::F17,
+    egui::Key::F18,
+    egui::Key::F19,
+    egui::Key::F20,
+    egui::Key::F21,
+    egui::Key::F22,
+    egui::Key::F23,
+    egui::Key::F24,
     egui::Key::Tab,
     egui::Key::Space,
     egui::Key::Enter,
@@ -520,6 +529,15 @@ fn egui_key_to_code(key: egui::Key) -> Option<u16> {
         Key::F13 => 0x7C,
         Key::F14 => 0x7D,
         Key::F15 => 0x7E,
+        Key::F16 => 0x7F,
+        Key::F17 => 0x80,
+        Key::F18 => 0x81,
+        Key::F19 => 0x82,
+        Key::F20 => 0x83,
+        Key::F21 => 0x84,
+        Key::F22 => 0x85,
+        Key::F23 => 0x86,
+        Key::F24 => 0x87,
         Key::Tab => 0x09,
         Key::Space => 0x20,
         Key::Enter => 0x0D,
@@ -595,7 +613,7 @@ fn egui_key_to_code(key: egui::Key) -> Option<u16> {
     use egui::Key;
     let code: u16 = match key {
         // Function keys: KEY_F1 = 59, KEY_F2 = 60, ... KEY_F10 = 68;
-        // KEY_F11 = 87, KEY_F12 = 88. F13–F15 are 183–185.
+        // KEY_F11 = 87, KEY_F12 = 88. F13–F24 are 183–194.
         Key::F1 => 59,
         Key::F2 => 60,
         Key::F3 => 61,
@@ -611,6 +629,15 @@ fn egui_key_to_code(key: egui::Key) -> Option<u16> {
         Key::F13 => 183,
         Key::F14 => 184,
         Key::F15 => 185,
+        Key::F16 => 186,
+        Key::F17 => 187,
+        Key::F18 => 188,
+        Key::F19 => 189,
+        Key::F20 => 190,
+        Key::F21 => 191,
+        Key::F22 => 192,
+        Key::F23 => 193,
+        Key::F24 => 194,
         Key::Tab => 15,
         Key::Space => 57,
         Key::Enter => 28,
@@ -696,6 +723,18 @@ fn code_to_label(vk: u16) -> String {
         0x79 => "F10".into(),
         0x7A => "F11".into(),
         0x7B => "F12".into(),
+        0x7C => "F13".into(),
+        0x7D => "F14".into(),
+        0x7E => "F15".into(),
+        0x7F => "F16".into(),
+        0x80 => "F17".into(),
+        0x81 => "F18".into(),
+        0x82 => "F19".into(),
+        0x83 => "F20".into(),
+        0x84 => "F21".into(),
+        0x85 => "F22".into(),
+        0x86 => "F23".into(),
+        0x87 => "F24".into(),
         0x09 => "Tab".into(),
         0x20 => "Space".into(),
         0x0D => "Enter".into(),
@@ -736,6 +775,15 @@ fn code_to_label(code: u16) -> String {
         183 => "F13".into(),
         184 => "F14".into(),
         185 => "F15".into(),
+        186 => "F16".into(),
+        187 => "F17".into(),
+        188 => "F18".into(),
+        189 => "F19".into(),
+        190 => "F20".into(),
+        191 => "F21".into(),
+        192 => "F22".into(),
+        193 => "F23".into(),
+        194 => "F24".into(),
         // Common control keys.
         15 => "Tab".into(),
         57 => "Space".into(),
@@ -859,4 +907,56 @@ pub fn run(config: Config, live: Arc<Mutex<LiveSettings>>) -> Result<(), eframe:
         options,
         Box::new(move |cc| Ok(Box::new(ConfigPanel::new(cc, config, live)))),
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn f_keys_16_to_24() -> Vec<(egui::Key, &'static str)> {
+        vec![
+            (egui::Key::F16, "F16"),
+            (egui::Key::F17, "F17"),
+            (egui::Key::F18, "F18"),
+            (egui::Key::F19, "F19"),
+            (egui::Key::F20, "F20"),
+            (egui::Key::F21, "F21"),
+            (egui::Key::F22, "F22"),
+            (egui::Key::F23, "F23"),
+            (egui::Key::F24, "F24"),
+        ]
+    }
+
+    #[test]
+    fn supported_keys_includes_f16_through_f24() {
+        for (key, name) in f_keys_16_to_24() {
+            assert!(
+                SUPPORTED_KEYS.contains(&key),
+                "{name} not in SUPPORTED_KEYS — bind UI cannot capture it"
+            );
+        }
+    }
+
+    #[test]
+    fn egui_key_to_code_maps_f16_through_f24() {
+        for (key, name) in f_keys_16_to_24() {
+            assert!(
+                egui_key_to_code(key).is_some(),
+                "{name} has no native key code mapping"
+            );
+        }
+    }
+
+    #[test]
+    fn code_to_label_round_trips_f16_through_f24() {
+        for (key, name) in f_keys_16_to_24() {
+            let code = egui_key_to_code(key)
+                .unwrap_or_else(|| panic!("{name} unmapped, can't round-trip"));
+            assert_eq!(
+                code_to_label(code),
+                name,
+                "code {code} for {name} renders as raw fallback instead of the F-key name"
+            );
+        }
+    }
 }

--- a/src/eve_match.rs
+++ b/src/eve_match.rs
@@ -10,6 +10,20 @@
 //! which is the original CCP binary name. Anything else matching the
 //! title heuristic isn't the game.
 
+/// Pure: does the basename of a Windows executable path equal
+/// `exefile.exe` (case-insensitive)? Used by the Windows-side
+/// `pid_is_eve_client` to filter `QueryFullProcessImageNameW` output.
+/// Lives here so it can be unit-tested on any host. The Linux build
+/// doesn't call this directly (it uses /proc/<pid>/comm instead), but
+/// the tests still exercise it.
+#[cfg_attr(not(windows), allow(dead_code))]
+pub fn path_basename_is_eve_exe(path: &str) -> bool {
+    path.rsplit(['\\', '/'])
+        .next()
+        .map(|name| name.eq_ignore_ascii_case("exefile.exe"))
+        .unwrap_or(false)
+}
+
 /// Linux/Unix: returns true if `/proc/<pid>/comm` is `exefile.exe`.
 /// `comm` is the in-kernel short name of the executable (truncated to
 /// 15 chars but `exefile.exe` is 11). Wine/Proton preserves the comm
@@ -22,4 +36,85 @@ pub fn pid_is_eve_client(pid: u32) -> bool {
     std::fs::read_to_string(format!("/proc/{}/comm", pid))
         .map(|s| s.trim() == "exefile.exe")
         .unwrap_or(false)
+}
+
+/// Windows: returns true if the process backing `pid` is the EVE
+/// client. Resolves the full executable image path via
+/// `QueryFullProcessImageNameW` and compares the basename against
+/// `exefile.exe` via the pure `path_basename_is_eve_exe`. Returns
+/// false for any failure (process gone, access denied, etc.).
+#[cfg(windows)]
+pub fn pid_is_eve_client(pid: u32) -> bool {
+    use windows::core::PWSTR;
+    use windows::Win32::Foundation::CloseHandle;
+    use windows::Win32::System::Threading::{
+        OpenProcess, QueryFullProcessImageNameW, PROCESS_NAME_FORMAT,
+        PROCESS_QUERY_LIMITED_INFORMATION,
+    };
+    unsafe {
+        let Ok(handle) = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, pid) else {
+            return false;
+        };
+        let mut buf = [0u16; 1024];
+        let mut size = buf.len() as u32;
+        let result = QueryFullProcessImageNameW(
+            handle,
+            PROCESS_NAME_FORMAT(0),
+            PWSTR(buf.as_mut_ptr()),
+            &mut size,
+        );
+        let _ = CloseHandle(handle);
+        if result.is_err() {
+            return false;
+        }
+        let path = String::from_utf16_lossy(&buf[..size as usize]);
+        path_basename_is_eve_exe(&path)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn path_basename_matches_canonical_steam_path() {
+        assert!(path_basename_is_eve_exe(
+            "C:\\Program Files (x86)\\Steam\\steamapps\\common\\EVE\\bin64\\exefile.exe"
+        ));
+    }
+
+    #[test]
+    fn path_basename_is_case_insensitive() {
+        assert!(path_basename_is_eve_exe("C:\\anywhere\\ExeFile.EXE"));
+        assert!(path_basename_is_eve_exe("EXEFILE.EXE"));
+    }
+
+    #[test]
+    fn path_basename_rejects_non_eve_executables() {
+        assert!(!path_basename_is_eve_exe(
+            "C:\\Windows\\System32\\notepad.exe"
+        ));
+        assert!(!path_basename_is_eve_exe("exefile2.exe"));
+        assert!(!path_basename_is_eve_exe("exefile.ex"));
+    }
+
+    #[test]
+    fn path_basename_handles_forward_slash_separators() {
+        // QueryFullProcessImageNameW returns backslash-separated paths,
+        // but Wine on Linux occasionally normalises to forward slashes
+        // when crossing the prefix boundary. Accept both.
+        assert!(path_basename_is_eve_exe(
+            "/wine/prefix/drive_c/eve/exefile.exe"
+        ));
+    }
+
+    #[test]
+    fn path_basename_handles_bare_filename() {
+        assert!(path_basename_is_eve_exe("exefile.exe"));
+    }
+
+    #[test]
+    fn path_basename_rejects_empty_string() {
+        assert!(!path_basename_is_eve_exe(""));
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,8 +21,8 @@ mod window_manager;
 
 mod version_check;
 
-#[cfg(unix)]
 mod eve_match;
+
 #[cfg(unix)]
 mod keyboard_listener;
 #[cfg(unix)]
@@ -42,6 +42,8 @@ mod preview_windows;
 mod windows_input;
 #[cfg(windows)]
 mod windows_manager;
+
+mod windows_helpers;
 
 use anyhow::Result;
 use config::{Config, LiveSettings};

--- a/src/windows_helpers.rs
+++ b/src/windows_helpers.rs
@@ -1,0 +1,383 @@
+//! Pure logic extracted from `windows_input` / `windows_manager` so it
+//! can be unit-tested on any host — including from a Linux dev box that
+//! can't run the Win32 calls these helpers feed into. The functions
+//! here take primitive inputs (u16 VK codes, u32 thread IDs, plain
+//! structs) and return data the Windows-only consumers then act on.
+//!
+//! Compiled unconditionally; on Linux only the tests use it (the
+//! actual call sites in `windows_input` / `windows_manager` are
+//! cfg-gated and never linked). The module-wide `dead_code` allow
+//! covers that intentional Linux-side unused-ness — the unit tests
+//! still exercise every item below.
+#![allow(dead_code)]
+
+use crate::config::CharacterHotkey;
+use std::collections::HashMap;
+
+/// Direction of a cycle action. Used by `classify_xbutton` and by the
+/// Windows input listener's internal message dispatch. Cross-platform
+/// to keep tests free of Win32 imports.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum CycleDirection {
+    Forward,
+    Backward,
+}
+
+/// The three keyboard modifiers Win32 RegisterHotKey accepts as a
+/// global hotkey qualifier. `None` is represented by `Option<ModifierKind>::None`
+/// at the use site, not a fourth variant — matches the existing
+/// `Option<u16> modifier_key` shape in `Config`.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum ModifierKind {
+    Shift,
+    Ctrl,
+    Alt,
+}
+
+/// Map a Win32 VK code to the modifier it represents, or None if the
+/// code isn't a modifier. Covers both unified (`VK_SHIFT`) and
+/// left/right (`VK_LSHIFT` / `VK_RSHIFT`) variants since Config may
+/// store either depending on how the bind was captured.
+pub fn modifier_kind(vk: u16) -> Option<ModifierKind> {
+    // Values hard-coded against the Win32 VK_ constants so this file
+    // doesn't need the `windows` crate (which only links on Windows).
+    // Verified against `windows::Win32::UI::Input::KeyboardAndMouse`:
+    //   VK_SHIFT   = 0x10, VK_LSHIFT = 0xA0, VK_RSHIFT = 0xA1
+    //   VK_CONTROL = 0x11, VK_LCONTROL = 0xA2, VK_RCONTROL = 0xA3
+    //   VK_MENU    = 0x12, VK_LMENU = 0xA4, VK_RMENU = 0xA5
+    match vk {
+        0x10 | 0xA0 | 0xA1 => Some(ModifierKind::Shift),
+        0x11 | 0xA2 | 0xA3 => Some(ModifierKind::Ctrl),
+        0x12 | 0xA4 | 0xA5 => Some(ModifierKind::Alt),
+        _ => None,
+    }
+}
+
+/// Pure classification of a raw mouse XBUTTON code into a cycle
+/// direction, given the user-configured forward/backward button codes.
+/// Returns None when the press isn't bound to either direction —
+/// caller passes through to the next hook with no side effect.
+pub fn classify_xbutton(
+    xbutton: u16,
+    forward_button: u16,
+    backward_button: u16,
+) -> Option<CycleDirection> {
+    if xbutton == forward_button {
+        Some(CycleDirection::Forward)
+    } else if xbutton == backward_button {
+        Some(CycleDirection::Backward)
+    } else {
+        None
+    }
+}
+
+/// Whether the low-level focus-stealing fallback in `force_activate`
+/// should attach a foreign thread's input queue to ours. The Win32
+/// `AttachThreadInput` call is a no-op (and returns false) if you ask
+/// it to attach a thread to itself, and there's no point attaching a
+/// thread that's already attached or one we don't know exists (id 0).
+///
+/// `exclude` lists thread IDs we've already attached or otherwise
+/// shouldn't attempt — typically the target thread when evaluating
+/// whether to also attach the previous foreground thread.
+pub fn should_attach_thread_input(thread: u32, current: u32, exclude: &[u32]) -> bool {
+    thread != 0 && thread != current && !exclude.contains(&thread)
+}
+
+/// A planned cycle (forward/backward) hotkey registration. Output of
+/// `plan_cycle_hotkeys`; the Windows consumer turns each entry into a
+/// `RegisterHotKey` call.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CycleHotkeyPlan {
+    pub id: i32,
+    pub modifier: Option<ModifierKind>,
+    pub vk: u16,
+}
+
+/// Plan which cycle hotkeys to register given the user's config.
+///
+/// Three relevant shapes:
+/// * Cycle hotkeys disabled → no entries.
+/// * Forward == Backward key, no modifier configured → forward only,
+///   no modifier (the backward registration is unreachable so we skip
+///   it; the modifier-bearing match in the modifier-key gating path
+///   below is what makes shift-tab work).
+/// * Forward == Backward key, modifier configured → forward (no mod)
+///   AND backward (with modifier).
+/// * Forward != Backward → both registered, neither with a modifier.
+///   The `modifier_key` setting is intentionally ignored in this case;
+///   it's only meaningful when forward/backward overlap.
+pub fn plan_cycle_hotkeys(
+    enable: bool,
+    forward_vk: u16,
+    backward_vk: u16,
+    modifier_vk: Option<u16>,
+    forward_id: i32,
+    backward_id: i32,
+) -> Vec<CycleHotkeyPlan> {
+    if !enable {
+        return Vec::new();
+    }
+    let mut plans = vec![CycleHotkeyPlan {
+        id: forward_id,
+        modifier: None,
+        vk: forward_vk,
+    }];
+    let same_key = forward_vk == backward_vk;
+    let backward_modifier = if same_key {
+        modifier_vk.and_then(modifier_kind)
+    } else {
+        None
+    };
+    if !same_key || backward_modifier.is_some() {
+        plans.push(CycleHotkeyPlan {
+            id: backward_id,
+            modifier: backward_modifier,
+            vk: backward_vk,
+        });
+    }
+    plans
+}
+
+/// A planned per-character hotkey registration.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CharacterHotkeyPlan {
+    pub id: i32,
+    pub character_name: String,
+    pub modifier: Option<ModifierKind>,
+    pub vk: u16,
+}
+
+/// Plan per-character hotkey registrations in the user-configured
+/// character order. Skips characters that have no hotkey entry or
+/// whose VK is the placeholder 0 (the user picked a modifier but
+/// hasn't captured a key yet). IDs start at `base_id` and advance by
+/// one for every emitted plan — entries that are skipped don't burn an
+/// ID, so the ID sequence is dense.
+pub fn plan_character_hotkeys(
+    characters: &[String],
+    character_hotkeys: &HashMap<String, CharacterHotkey>,
+    base_id: i32,
+) -> Vec<CharacterHotkeyPlan> {
+    let mut out = Vec::new();
+    let mut next_id = base_id;
+    for name in characters {
+        let Some(hk) = character_hotkeys.get(name) else {
+            continue;
+        };
+        if hk.vk == 0 {
+            continue;
+        }
+        out.push(CharacterHotkeyPlan {
+            id: next_id,
+            character_name: name.clone(),
+            modifier: hk.modifier.and_then(modifier_kind),
+            vk: hk.vk,
+        });
+        next_id += 1;
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ---- modifier_kind --------------------------------------------------
+
+    #[test]
+    fn modifier_kind_recognises_unified_vk_constants() {
+        assert_eq!(modifier_kind(0x10), Some(ModifierKind::Shift)); // VK_SHIFT
+        assert_eq!(modifier_kind(0x11), Some(ModifierKind::Ctrl)); // VK_CONTROL
+        assert_eq!(modifier_kind(0x12), Some(ModifierKind::Alt)); // VK_MENU
+    }
+
+    #[test]
+    fn modifier_kind_recognises_left_and_right_variants() {
+        assert_eq!(modifier_kind(0xA0), Some(ModifierKind::Shift));
+        assert_eq!(modifier_kind(0xA1), Some(ModifierKind::Shift));
+        assert_eq!(modifier_kind(0xA2), Some(ModifierKind::Ctrl));
+        assert_eq!(modifier_kind(0xA3), Some(ModifierKind::Ctrl));
+        assert_eq!(modifier_kind(0xA4), Some(ModifierKind::Alt));
+        assert_eq!(modifier_kind(0xA5), Some(ModifierKind::Alt));
+    }
+
+    #[test]
+    fn modifier_kind_returns_none_for_non_modifier_keys() {
+        assert_eq!(modifier_kind(0x70), None); // F1
+        assert_eq!(modifier_kind(0x41), None); // A
+        assert_eq!(modifier_kind(0), None);
+        assert_eq!(modifier_kind(0xFF), None);
+    }
+
+    // ---- classify_xbutton ----------------------------------------------
+
+    #[test]
+    fn classify_xbutton_returns_forward_when_press_matches_forward_binding() {
+        assert_eq!(classify_xbutton(2, 2, 1), Some(CycleDirection::Forward));
+    }
+
+    #[test]
+    fn classify_xbutton_returns_backward_when_press_matches_backward_binding() {
+        assert_eq!(classify_xbutton(1, 2, 1), Some(CycleDirection::Backward));
+    }
+
+    #[test]
+    fn classify_xbutton_returns_none_for_unbound_button() {
+        assert_eq!(classify_xbutton(3, 2, 1), None);
+    }
+
+    #[test]
+    fn classify_xbutton_forward_wins_when_forward_and_backward_collide() {
+        // If a user managed to bind both directions to the same button,
+        // forward shadows backward — that's the order the consumer
+        // expects.
+        assert_eq!(classify_xbutton(2, 2, 2), Some(CycleDirection::Forward));
+    }
+
+    // ---- should_attach_thread_input ------------------------------------
+
+    #[test]
+    fn should_attach_thread_input_rejects_zero_id() {
+        assert!(!should_attach_thread_input(0, 100, &[]));
+    }
+
+    #[test]
+    fn should_attach_thread_input_rejects_self_attach() {
+        assert!(!should_attach_thread_input(100, 100, &[]));
+    }
+
+    #[test]
+    fn should_attach_thread_input_rejects_already_excluded() {
+        assert!(!should_attach_thread_input(200, 100, &[200]));
+    }
+
+    #[test]
+    fn should_attach_thread_input_allows_valid_distinct_thread() {
+        assert!(should_attach_thread_input(200, 100, &[]));
+        assert!(should_attach_thread_input(200, 100, &[300]));
+    }
+
+    // ---- plan_cycle_hotkeys --------------------------------------------
+
+    #[test]
+    fn plan_cycle_hotkeys_returns_empty_when_disabled() {
+        let plans = plan_cycle_hotkeys(false, 0x70, 0x70, Some(0x10), 1, 2);
+        assert!(plans.is_empty());
+    }
+
+    #[test]
+    fn plan_cycle_hotkeys_emits_forward_and_backward_when_keys_differ() {
+        let plans = plan_cycle_hotkeys(true, 0x70, 0x71, None, 1, 2);
+        assert_eq!(
+            plans,
+            vec![
+                CycleHotkeyPlan {
+                    id: 1,
+                    modifier: None,
+                    vk: 0x70
+                },
+                CycleHotkeyPlan {
+                    id: 2,
+                    modifier: None,
+                    vk: 0x71
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn plan_cycle_hotkeys_ignores_modifier_when_keys_differ() {
+        // The modifier_key field is only meaningful when forward and
+        // backward share a VK. With distinct keys, modifier must NOT
+        // apply to the backward entry — matches the original
+        // do_register_hotkeys behavior.
+        let plans = plan_cycle_hotkeys(true, 0x70, 0x71, Some(0x10), 1, 2);
+        assert_eq!(plans[1].modifier, None);
+    }
+
+    #[test]
+    fn plan_cycle_hotkeys_drops_backward_when_same_key_and_no_modifier() {
+        let plans = plan_cycle_hotkeys(true, 0x09, 0x09, None, 1, 2);
+        assert_eq!(plans.len(), 1);
+        assert_eq!(plans[0].id, 1);
+    }
+
+    #[test]
+    fn plan_cycle_hotkeys_uses_modifier_on_backward_when_keys_match() {
+        // The classic "Tab forward, Shift+Tab backward" config.
+        let plans = plan_cycle_hotkeys(true, 0x09, 0x09, Some(0x10), 1, 2);
+        assert_eq!(plans.len(), 2);
+        assert_eq!(plans[0].modifier, None);
+        assert_eq!(plans[1].modifier, Some(ModifierKind::Shift));
+        assert_eq!(plans[1].vk, 0x09);
+    }
+
+    #[test]
+    fn plan_cycle_hotkeys_drops_backward_when_modifier_vk_isnt_a_modifier() {
+        // Defensive: if Config somehow stores a non-modifier VK as the
+        // modifier_key, the plan treats it as no modifier — same key +
+        // no modifier ⇒ skip backward.
+        let plans = plan_cycle_hotkeys(true, 0x09, 0x09, Some(0x41), 1, 2); // 'A'
+        assert_eq!(plans.len(), 1);
+    }
+
+    // ---- plan_character_hotkeys ----------------------------------------
+
+    fn hk(vk: u16, modifier: Option<u16>) -> CharacterHotkey {
+        CharacterHotkey { vk, modifier }
+    }
+
+    #[test]
+    fn plan_character_hotkeys_emits_entries_in_character_order() {
+        let characters = vec!["Beta".to_string(), "Alpha".to_string()];
+        let mut hotkeys = HashMap::new();
+        hotkeys.insert("Alpha".to_string(), hk(0x70, None));
+        hotkeys.insert("Beta".to_string(), hk(0x71, None));
+        let plans = plan_character_hotkeys(&characters, &hotkeys, 2000);
+        assert_eq!(plans.len(), 2);
+        assert_eq!(plans[0].character_name, "Beta");
+        assert_eq!(plans[0].id, 2000);
+        assert_eq!(plans[1].character_name, "Alpha");
+        assert_eq!(plans[1].id, 2001);
+    }
+
+    #[test]
+    fn plan_character_hotkeys_skips_characters_without_a_binding() {
+        let characters = vec!["Alpha".to_string(), "Beta".to_string()];
+        let mut hotkeys = HashMap::new();
+        hotkeys.insert("Beta".to_string(), hk(0x71, None));
+        let plans = plan_character_hotkeys(&characters, &hotkeys, 2000);
+        assert_eq!(plans.len(), 1);
+        assert_eq!(plans[0].character_name, "Beta");
+        // No ID burned for the skipped character.
+        assert_eq!(plans[0].id, 2000);
+    }
+
+    #[test]
+    fn plan_character_hotkeys_skips_placeholder_vk_zero() {
+        let characters = vec!["Alpha".to_string()];
+        let mut hotkeys = HashMap::new();
+        hotkeys.insert("Alpha".to_string(), hk(0, Some(0x10)));
+        let plans = plan_character_hotkeys(&characters, &hotkeys, 2000);
+        assert!(plans.is_empty());
+    }
+
+    #[test]
+    fn plan_character_hotkeys_translates_modifier_vk_into_modifier_kind() {
+        let characters = vec!["Alpha".to_string()];
+        let mut hotkeys = HashMap::new();
+        hotkeys.insert("Alpha".to_string(), hk(0x70, Some(0x11))); // Ctrl
+        let plans = plan_character_hotkeys(&characters, &hotkeys, 2000);
+        assert_eq!(plans[0].modifier, Some(ModifierKind::Ctrl));
+    }
+
+    #[test]
+    fn plan_character_hotkeys_treats_non_modifier_vk_as_no_modifier() {
+        let characters = vec!["Alpha".to_string()];
+        let mut hotkeys = HashMap::new();
+        hotkeys.insert("Alpha".to_string(), hk(0x70, Some(0x41))); // 'A' isn't a modifier
+        let plans = plan_character_hotkeys(&characters, &hotkeys, 2000);
+        assert_eq!(plans[0].modifier, None);
+    }
+}

--- a/src/windows_input.rs
+++ b/src/windows_input.rs
@@ -1,6 +1,9 @@
 use crate::config::Config;
 use crate::cycle_state::CycleState;
 use crate::window_manager::WindowManager;
+use crate::windows_helpers::{
+    classify_xbutton, plan_character_hotkeys, plan_cycle_hotkeys, CycleDirection, ModifierKind,
+};
 use anyhow::{Context, Result};
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
@@ -11,8 +14,6 @@ use windows::Win32::System::LibraryLoader::GetModuleHandleW;
 use windows::Win32::System::Threading::GetCurrentThreadId;
 use windows::Win32::UI::Input::KeyboardAndMouse::{
     RegisterHotKey, UnregisterHotKey, HOT_KEY_MODIFIERS, MOD_ALT, MOD_CONTROL, MOD_SHIFT,
-    VK_CONTROL, VK_LCONTROL, VK_LMENU, VK_LSHIFT, VK_MENU, VK_RCONTROL, VK_RMENU, VK_RSHIFT,
-    VK_SHIFT,
 };
 use windows::Win32::UI::WindowsAndMessaging::{
     CallNextHookEx, GetMessageW, PostThreadMessageW, SetWindowsHookExW, HHOOK, MSG, MSLLHOOKSTRUCT,
@@ -119,13 +120,13 @@ unsafe extern "system" fn mouse_hook_proc(code: i32, wparam: WPARAM, lparam: LPA
         }
 
         if let Some(ctx) = HOOK_CTX.get() {
-            let post = if xbutton == ctx.forward_button {
-                Some(WM_USER_FORWARD)
-            } else if xbutton == ctx.backward_button {
-                Some(WM_USER_BACKWARD)
-            } else {
-                None
-            };
+            let post =
+                classify_xbutton(xbutton, ctx.forward_button, ctx.backward_button).map(|dir| {
+                    match dir {
+                        CycleDirection::Forward => WM_USER_FORWARD,
+                        CycleDirection::Backward => WM_USER_BACKWARD,
+                    }
+                });
 
             if let Some(msg) = post {
                 // PostThreadMessageW returns false if the thread queue is
@@ -137,12 +138,16 @@ unsafe extern "system" fn mouse_hook_proc(code: i32, wparam: WPARAM, lparam: LPA
     CallNextHookEx(None, code, wparam, lparam)
 }
 
-fn vk_to_modifier(vk: u16) -> HOT_KEY_MODIFIERS {
-    match vk {
-        v if v == VK_SHIFT.0 || v == VK_LSHIFT.0 || v == VK_RSHIFT.0 => MOD_SHIFT,
-        v if v == VK_CONTROL.0 || v == VK_LCONTROL.0 || v == VK_RCONTROL.0 => MOD_CONTROL,
-        v if v == VK_MENU.0 || v == VK_LMENU.0 || v == VK_RMENU.0 => MOD_ALT,
-        _ => HOT_KEY_MODIFIERS(0),
+/// Translate a planner-output ModifierKind into the Win32
+/// HOT_KEY_MODIFIERS bitmask RegisterHotKey expects. The planner is
+/// kept platform-independent (see `windows_helpers`) so this thin
+/// adapter is the only place that knows about MOD_SHIFT/etc.
+fn modifier_to_winapi(kind: Option<ModifierKind>) -> HOT_KEY_MODIFIERS {
+    match kind {
+        Some(ModifierKind::Shift) => MOD_SHIFT,
+        Some(ModifierKind::Ctrl) => MOD_CONTROL,
+        Some(ModifierKind::Alt) => MOD_ALT,
+        None => HOT_KEY_MODIFIERS(0),
     }
 }
 
@@ -282,61 +287,44 @@ fn run_listener(
 /// per-character hotkey, all on the current thread. Silently ignores
 /// failures (another app may own the key) — the listener still runs,
 /// it just won't fire for the contested key.
+///
+/// All ID assignment and modifier-conditional logic lives in
+/// `windows_helpers::plan_cycle_hotkeys` / `plan_character_hotkeys`
+/// (with unit tests). This function only consumes the plans and makes
+/// the Win32 calls.
 unsafe fn do_register_hotkeys(config: &Config) {
-    // Cycle hotkeys — gated by enable_keyboard_buttons so users can
-    // disable cycle hotkeys while still using per-character ones.
-    if config.enable_keyboard_buttons {
+    for plan in plan_cycle_hotkeys(
+        config.enable_keyboard_buttons,
+        config.forward_key,
+        config.backward_key,
+        config.modifier_key,
+        HOTKEY_FORWARD_ID,
+        HOTKEY_BACKWARD_ID,
+    ) {
         let _ = RegisterHotKey(
             None,
-            HOTKEY_FORWARD_ID,
-            HOT_KEY_MODIFIERS(0),
-            config.forward_key as u32,
+            plan.id,
+            modifier_to_winapi(plan.modifier),
+            plan.vk as u32,
         );
-        let modifier = config.modifier_key.map(vk_to_modifier);
-        let backward_mod = if config.forward_key == config.backward_key {
-            modifier.unwrap_or(HOT_KEY_MODIFIERS(0))
-        } else {
-            HOT_KEY_MODIFIERS(0)
-        };
-        if config.forward_key != config.backward_key || backward_mod.0 != 0 {
-            let _ = RegisterHotKey(
-                None,
-                HOTKEY_BACKWARD_ID,
-                backward_mod,
-                config.backward_key as u32,
-            );
-        }
     }
 
-    // Per-character hotkeys — iterate the characters list in order so
-    // hotkey IDs are stable for the same config, and populate the
-    // ID → name lookup.
     let mut lookup = character_lookup().lock().unwrap();
     lookup.clear();
-    let mut next_id = HOTKEY_CHARACTER_BASE;
-    for name in &config.characters {
-        let Some(hk) = config.character_hotkeys.get(name) else {
-            continue;
-        };
-        // vk == 0 is a placeholder entry — the user picked a modifier
-        // but hasn't captured a key yet. Skip registration; the entry
-        // becomes active only once a real VK is bound.
-        if hk.vk == 0 {
-            continue;
-        }
-        let modifier = hk
-            .modifier
-            .map(vk_to_modifier)
-            .unwrap_or(HOT_KEY_MODIFIERS(0));
-        if RegisterHotKey(None, next_id, modifier, hk.vk as u32).is_ok() {
-            lookup.insert(next_id, name.clone());
+    for plan in plan_character_hotkeys(
+        &config.characters,
+        &config.character_hotkeys,
+        HOTKEY_CHARACTER_BASE,
+    ) {
+        let modifier = modifier_to_winapi(plan.modifier);
+        if RegisterHotKey(None, plan.id, modifier, plan.vk as u32).is_ok() {
+            lookup.insert(plan.id, plan.character_name);
         } else {
             eprintln!(
                 "Failed to register per-character hotkey for '{}' (another app may own it)",
-                name
+                plan.character_name
             );
         }
-        next_id += 1;
     }
 }
 
@@ -354,12 +342,6 @@ fn unregister_hotkeys() {
         }
         lookup.clear();
     }
-}
-
-#[derive(Copy, Clone)]
-enum CycleDirection {
-    Forward,
-    Backward,
 }
 
 fn perform_cycle(

--- a/src/windows_manager.rs
+++ b/src/windows_manager.rs
@@ -1,13 +1,11 @@
 use crate::config::Config;
+use crate::eve_match::pid_is_eve_client;
 use crate::window_manager::{EveWindow, WindowManager};
+use crate::windows_helpers::should_attach_thread_input;
 use anyhow::{Context, Result};
 use std::ffi::c_void;
-use windows::core::PWSTR;
-use windows::Win32::Foundation::{CloseHandle, BOOL, HWND, LPARAM, TRUE, WPARAM};
-use windows::Win32::System::Threading::{
-    AttachThreadInput, GetCurrentThreadId, OpenProcess, QueryFullProcessImageNameW,
-    PROCESS_NAME_FORMAT, PROCESS_QUERY_LIMITED_INFORMATION,
-};
+use windows::Win32::Foundation::{BOOL, HWND, LPARAM, TRUE, WPARAM};
+use windows::Win32::System::Threading::{AttachThreadInput, GetCurrentThreadId};
 use windows::Win32::UI::Input::KeyboardAndMouse::SetFocus;
 use windows::Win32::UI::WindowsAndMessaging::{
     BringWindowToTop, EnumWindows, GetForegroundWindow, GetWindowTextLengthW, GetWindowTextW,
@@ -44,36 +42,6 @@ fn read_window_title(hwnd: HWND) -> String {
         return String::new();
     }
     String::from_utf16_lossy(&buf[..copied as usize])
-}
-
-/// Process-name filter for EVE clients. The title-only check
-/// `starts_with("EVE - ")` is satisfied by browser tabs, Discord
-/// channels, and other apps that happen to use that prefix in their
-/// window title. The reliable signal is that the owning process's
-/// image is `exefile.exe` — the actual EVE client binary.
-fn pid_is_eve_client(pid: u32) -> bool {
-    unsafe {
-        let Ok(handle) = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, pid) else {
-            return false;
-        };
-        let mut buf = [0u16; 1024];
-        let mut size = buf.len() as u32;
-        let result = QueryFullProcessImageNameW(
-            handle,
-            PROCESS_NAME_FORMAT(0),
-            PWSTR(buf.as_mut_ptr()),
-            &mut size,
-        );
-        let _ = CloseHandle(handle);
-        if result.is_err() {
-            return false;
-        }
-        let path = String::from_utf16_lossy(&buf[..size as usize]);
-        path.rsplit('\\')
-            .next()
-            .map(|name| name.eq_ignore_ascii_case("exefile.exe"))
-            .unwrap_or(false)
-    }
 }
 
 unsafe extern "system" fn enum_collect_eve(hwnd: HWND, lparam: LPARAM) -> BOOL {
@@ -143,13 +111,15 @@ fn force_activate(target: HWND) {
             GetWindowThreadProcessId(foreground, None)
         };
 
-        let attached_target = target_thread != 0
-            && target_thread != current_thread
+        // Gate the AttachThreadInput calls on the pure attach-eligibility
+        // rule (nonzero, not self, not already attached). See
+        // `windows_helpers::should_attach_thread_input` for the rule and
+        // its tests.
+        let attached_target = should_attach_thread_input(target_thread, current_thread, &[])
             && AttachThreadInput(current_thread, target_thread, true).as_bool();
-        let attached_foreground = foreground_thread != 0
-            && foreground_thread != current_thread
-            && foreground_thread != target_thread
-            && AttachThreadInput(current_thread, foreground_thread, true).as_bool();
+        let attached_foreground =
+            should_attach_thread_input(foreground_thread, current_thread, &[target_thread])
+                && AttachThreadInput(current_thread, foreground_thread, true).as_bool();
 
         let _ = SetForegroundWindow(target);
         let _ = BringWindowToTop(target);


### PR DESCRIPTION
## Summary
- Extract pure logic from `windows_input.rs` / `windows_manager.rs` into `windows_helpers.rs`: hotkey planners, x-button classification, thread-attach gating, modifier resolution. All unit-testable on Linux.
- Move Windows `pid_is_eve_client` into `eve_match.rs` alongside the Linux version, with a shared pure `path_basename_is_eve_exe` helper.
- Fix #N (or: "fix F-key binding cap"): config panel now supports binding F16–F24 in addition to F1–F15. The bind UI previously silently dropped F16+ presses because they weren't in the polled key list.