### PR TITLE
Borderless preview mode + hover highlight

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ High-performance EVE Online multiboxing tool for Linux (X11 & Wayland) and Windo
 - **Drag-to-position with snap-to-dock** on previews and the list window; lockable layout for play
 - **Multi-compositor support** — X11, KDE Plasma (Wayland), Sway, Hyprland, GNOME (Wayland; auto-stack excepted)
 - **Minimize inactive clients** — optional, reduces resource usage when cycling away
+- **Borderless previews** — optional chrome-free mode; the character name sits on a translucent backdrop and turns red when the client is active or hovered
 
 ## Roadmap
 - Comprehensive documentation
@@ -206,6 +207,7 @@ enable_mouse_buttons = true
 forward_button = 276       # Button 9
 backward_button = 275      # Button 8
 minimize_inactive = false  # Minimize clients when cycling away (saves resources)
+borderless = false         # Chrome-free previews (name on backdrop; active/hovered = red)
 ```
 
 Per-character jump hotkeys live under `[character_hotkeys."Name"]` with `vk` and optional `modifier`; the config panel writes them for you.

--- a/src/config.rs
+++ b/src/config.rs
@@ -54,6 +54,14 @@ pub struct LiveSettings {
     /// away from reappears. Read live so the toggle takes effect without
     /// a restart.
     pub hide_active_preview: bool,
+    /// When true, previews drop the chrome (title strip + colored
+    /// border) and render the thumbnail edge-to-edge. The character
+    /// name is still drawn over the top-left corner on a translucent
+    /// backdrop so it stays readable; the *active* client's name is
+    /// drawn in Nicotine red (the color the active border uses in
+    /// bordered mode) instead of cream. Read live so the toggle takes
+    /// effect without a restart.
+    pub borderless: bool,
 }
 
 impl LiveSettings {
@@ -66,6 +74,7 @@ impl LiveSettings {
             positions_locked: config.positions_locked,
             show_previews: config.show_previews,
             hide_active_preview: config.hide_active_preview,
+            borderless: config.borderless,
         }))
     }
 }
@@ -120,6 +129,12 @@ pub struct Config {
     /// client.
     #[serde(default = "default_hide_active_preview")]
     pub hide_active_preview: bool,
+    /// When true, previews render borderless (no title strip / colored
+    /// border) with the name overlaid on a translucent backdrop. Default
+    /// off. See the `LiveSettings::borderless` doc for the rendering
+    /// details.
+    #[serde(default = "default_borderless")]
+    pub borderless: bool,
     /// When true, the config panel locks preview width and height to a
     /// single aspect ratio and offers one "size" slider instead of
     /// separate width/height sliders. Purely a panel-side concern — the
@@ -271,6 +286,10 @@ fn default_hide_active_preview() -> bool {
     false
 }
 
+fn default_borderless() -> bool {
+    false
+}
+
 fn default_constrain_aspect() -> bool {
     false
 }
@@ -388,6 +407,7 @@ impl Config {
             preview_opacity: default_preview_opacity(),
             show_previews: default_show_previews(),
             hide_active_preview: default_hide_active_preview(),
+            borderless: default_borderless(),
             constrain_aspect: default_constrain_aspect(),
             toggle_previews_key: None,
             toggle_previews_modifier: None,
@@ -474,6 +494,7 @@ mod tests {
             preview_opacity: 100,
             show_previews: true,
             hide_active_preview: false,
+            borderless: false,
             constrain_aspect: false,
             toggle_previews_key: None,
             toggle_previews_modifier: None,
@@ -513,6 +534,7 @@ mod tests {
             preview_opacity: 100,
             show_previews: true,
             hide_active_preview: false,
+            borderless: false,
             constrain_aspect: false,
             toggle_previews_key: None,
             toggle_previews_modifier: None,
@@ -551,6 +573,7 @@ mod tests {
             preview_opacity: 55,
             show_previews: true,
             hide_active_preview: true,
+            borderless: true,
             constrain_aspect: true,
             toggle_previews_key: Some(67),
             toggle_previews_modifier: Some(42),
@@ -576,6 +599,10 @@ mod tests {
         assert!(
             deserialized.constrain_aspect,
             "constrain_aspect must survive a save/load round-trip"
+        );
+        assert!(
+            deserialized.borderless,
+            "borderless must survive a save/load round-trip"
         );
         assert_eq!(
             deserialized.toggle_previews_key,

--- a/src/config_panel/mod.rs
+++ b/src/config_panel/mod.rs
@@ -408,6 +408,7 @@ pub(super) enum Message {
     KeyEvent(iced::keyboard::Event),
     ShowPreviewsToggled(bool),
     HideActivePreviewToggled(bool),
+    BorderlessToggled(bool),
     ConstrainAspectToggled(bool),
     PreviewWidthChanged(u32),
     PreviewHeightChanged(u32),
@@ -570,6 +571,11 @@ fn update(panel: &mut Panel, message: Message) -> Task<Message> {
         Message::HideActivePreviewToggled(v) => {
             panel.config.hide_active_preview = v;
             panel.live.lock().unwrap().hide_active_preview = v;
+            panel.touch();
+        }
+        Message::BorderlessToggled(v) => {
+            panel.config.borderless = v;
+            panel.live.lock().unwrap().borderless = v;
             panel.touch();
         }
         Message::ConstrainAspectToggled(v) => {

--- a/src/config_panel/ui.rs
+++ b/src/config_panel/ui.rs
@@ -450,6 +450,9 @@ fn previews_section(panel: &Panel) -> Element<'_, Message> {
         checkbox(panel.config.hide_active_preview)
             .label("Hide the active client's preview")
             .on_toggle(Message::HideActivePreviewToggled),
+        checkbox(panel.config.borderless)
+            .label("Borderless previews (name on backdrop, active in red)")
+            .on_toggle(Message::BorderlessToggled),
         checkbox(panel.config.constrain_aspect)
             .label("Constrain aspect ratio")
             .on_toggle(Message::ConstrainAspectToggled),

--- a/src/preview_windows/mod.rs
+++ b/src/preview_windows/mod.rs
@@ -28,7 +28,9 @@ use windows::Win32::System::LibraryLoader::GetModuleHandleW;
 use windows::Win32::System::Threading::GetCurrentThreadId;
 use windows::Win32::UI::Accessibility::{SetWinEventHook, UnhookWinEvent, HWINEVENTHOOK};
 use windows::Win32::UI::HiDpi::GetDpiForSystem;
-use windows::Win32::UI::Input::KeyboardAndMouse::{ReleaseCapture, SetCapture};
+use windows::Win32::UI::Input::KeyboardAndMouse::{
+    ReleaseCapture, SetCapture, TrackMouseEvent, TME_LEAVE, TRACKMOUSEEVENT,
+};
 use windows::Win32::UI::WindowsAndMessaging::{
     CreateWindowExW, DefWindowProcW, DestroyWindow, DispatchMessageW, GetMessageW,
     GetSystemMetrics, GetWindowLongPtrW, GetWindowRect, KillTimer, LoadCursorW, RegisterClassExW,
@@ -36,7 +38,8 @@ use windows::Win32::UI::WindowsAndMessaging::{
     TranslateMessage, EVENT_SYSTEM_FOREGROUND, GWLP_USERDATA, HCURSOR, HICON, HMENU, HWND_TOPMOST,
     IDC_ARROW, LWA_ALPHA, MSG, SM_CXVIRTUALSCREEN, SM_CYVIRTUALSCREEN, SM_XVIRTUALSCREEN,
     SM_YVIRTUALSCREEN, SWP_NOACTIVATE, SWP_NOMOVE, SWP_NOSIZE, SW_HIDE, SW_SHOWNOACTIVATE,
-    WINEVENT_OUTOFCONTEXT, WM_DESTROY, WM_LBUTTONDOWN, WM_LBUTTONUP, WM_MOUSEMOVE, WM_PAINT,
+    WINEVENT_OUTOFCONTEXT, WM_DESTROY, WM_LBUTTONDOWN, WM_LBUTTONUP, WM_MOUSELEAVE, WM_MOUSEMOVE,
+    WM_PAINT,
     WM_TIMER, WNDCLASSEXW, WS_EX_LAYERED, WS_EX_NOACTIVATE, WS_EX_TOOLWINDOW, WS_EX_TOPMOST,
     WS_POPUP, WS_VISIBLE,
 };
@@ -183,6 +186,11 @@ struct PreviewWindowState {
     /// borderless (name-bar only) vs. bordered (chrome + frame) layout.
     /// Updated by reconcile via the GWLP_USERDATA pointer.
     borderless: bool,
+    /// True while the cursor is over this preview (WM_MOUSEMOVE sets it,
+    /// WM_MOUSELEAVE clears it). Drives the same red highlight as
+    /// `is_active`. Under click-through (WS_EX_TRANSPARENT) the window gets
+    /// no mouse messages, so this stays false — hover is inert there.
+    hovered: bool,
 }
 
 /// One owned preview window. Drop unregisters the DWM thumbnail.
@@ -740,6 +748,7 @@ impl PreviewManager {
             drag: DragState::default(),
             is_active: false,
             borderless,
+            hovered: false,
         });
         unsafe {
             SetWindowLongPtrW(hwnd, GWLP_USERDATA, Box::into_raw(per_window) as isize);
@@ -867,7 +876,7 @@ unsafe extern "system" fn preview_wnd_proc(
             paint_chrome(
                 hwnd,
                 &state.character_name,
-                state.is_active,
+                state.is_active || state.hovered,
                 state.borderless,
             );
             LRESULT(0)
@@ -891,6 +900,22 @@ unsafe extern "system" fn preview_wnd_proc(
             LRESULT(0)
         }
         WM_MOUSEMOVE => {
+            // Hover highlight: the first move after the cursor enters arms a
+            // WM_MOUSELEAVE notification and repaints the preview red (red
+            // border in bordered mode, red name in borderless). Under
+            // click-through (WS_EX_TRANSPARENT) no mouse messages arrive, so
+            // this never fires — hover is inert there, as required.
+            if !state.hovered {
+                state.hovered = true;
+                let mut tme = TRACKMOUSEEVENT {
+                    cbSize: std::mem::size_of::<TRACKMOUSEEVENT>() as u32,
+                    dwFlags: TME_LEAVE,
+                    hwndTrack: hwnd,
+                    dwHoverTime: 0,
+                };
+                let _ = TrackMouseEvent(&mut tme);
+                let _ = InvalidateRect(Some(hwnd), None, true);
+            }
             // Positions locked: don't track motion. Keeping drag_active
             // true means the subsequent WM_LBUTTONUP's `!dragged` path
             // still fires, so click-to-activate keeps working.
@@ -963,6 +988,14 @@ unsafe extern "system" fn preview_wnd_proc(
                     let _ = state.wm.activate_window(state.source_id);
                 }
                 state.drag.dragged = false;
+            }
+            LRESULT(0)
+        }
+        WM_MOUSELEAVE => {
+            // Cursor left the preview: drop the hover highlight and repaint.
+            if state.hovered {
+                state.hovered = false;
+                let _ = InvalidateRect(Some(hwnd), None, true);
             }
             LRESULT(0)
         }
@@ -1042,7 +1075,7 @@ fn nicotine_logo_font() -> HFONT {
 /// area. Border color is Nicotine red when this client is the system
 /// foreground window, otherwise the same dark color as the title strip
 /// (so it blends seamlessly).
-unsafe fn paint_chrome(hwnd: HWND, character_name: &str, is_active: bool, borderless: bool) {
+unsafe fn paint_chrome(hwnd: HWND, character_name: &str, highlight: bool, borderless: bool) {
     let mut ps = PAINTSTRUCT::default();
     let hdc = BeginPaint(hwnd, &mut ps);
 
@@ -1070,7 +1103,7 @@ unsafe fn paint_chrome(hwnd: HWND, character_name: &str, is_active: bool, border
         let _ = SetBkMode(hdc, TRANSPARENT);
         let _ = SetTextColor(
             hdc,
-            if is_active {
+            if highlight {
                 NICOTINE_RED
             } else {
                 COLORREF(0x00FF_FFFF)
@@ -1093,7 +1126,7 @@ unsafe fn paint_chrome(hwnd: HWND, character_name: &str, is_active: bool, border
         return;
     }
 
-    let chrome_color = if is_active { NICOTINE_RED } else { CHROME_DARK };
+    let chrome_color = if highlight { NICOTINE_RED } else { CHROME_DARK };
     let chrome_brush = CreateSolidBrush(chrome_color);
     let title_h = px(TITLE_HEIGHT);
     let border_w = px(BORDER_WIDTH);

--- a/src/preview_windows/mod.rs
+++ b/src/preview_windows/mod.rs
@@ -179,6 +179,10 @@ struct PreviewWindowState {
     /// window. Read from WM_PAINT to choose border color. Updated by
     /// reconcile via the GWLP_USERDATA pointer.
     is_active: bool,
+    /// Mirror of `LiveSettings.borderless`. Read from WM_PAINT to pick the
+    /// borderless (name-bar only) vs. bordered (chrome + frame) layout.
+    /// Updated by reconcile via the GWLP_USERDATA pointer.
+    borderless: bool,
 }
 
 /// One owned preview window. Drop unregisters the DWM thumbnail.
@@ -320,6 +324,7 @@ impl PreviewManager {
         // windows resize in real time.
         self.apply_live_size();
         self.apply_live_opacity();
+        self.apply_live_borderless();
         // Catches the setting being toggled and previews created since the
         // last tick; the instant per-cycle response comes from the same
         // call at the end of update_active.
@@ -523,7 +528,7 @@ impl PreviewManager {
                 let ptr =
                     GetWindowLongPtrW(preview.hwnd, GWLP_USERDATA) as *const PreviewWindowState;
                 if !ptr.is_null() {
-                    update_thumbnail_rect((*ptr).thumbnail, w, h);
+                    update_thumbnail_rect((*ptr).thumbnail, w, h, (*ptr).borderless);
                 }
                 // Repaint title strip + border at the new dimensions.
                 let _ = InvalidateRect(Some(preview.hwnd), None, true);
@@ -544,6 +549,31 @@ impl PreviewManager {
         self.config.preview_opacity = want;
         for preview in self.previews.values() {
             apply_window_opacity(preview.hwnd, want);
+        }
+    }
+
+    /// Read LiveSettings.borderless; if it flipped since the last reconcile,
+    /// re-register every preview's DWM thumbnail destination (full-window vs.
+    /// inset) and repaint so the frame appears/disappears live. Caches the
+    /// applied value in `self.config.borderless`, mirroring apply_live_size.
+    fn apply_live_borderless(&mut self) {
+        let want = self.live.lock().unwrap().borderless;
+        if want == self.config.borderless {
+            return;
+        }
+        self.config.borderless = want;
+        let w = self.config.preview_width as i32;
+        let h = self.config.preview_height as i32;
+        for preview in self.previews.values() {
+            unsafe {
+                let ptr =
+                    GetWindowLongPtrW(preview.hwnd, GWLP_USERDATA) as *mut PreviewWindowState;
+                if !ptr.is_null() {
+                    (*ptr).borderless = want;
+                    update_thumbnail_rect((*ptr).thumbnail, w, h, want);
+                }
+                let _ = InvalidateRect(Some(preview.hwnd), None, true);
+            }
         }
     }
 
@@ -698,7 +728,8 @@ impl PreviewManager {
             DwmRegisterThumbnail(hwnd, id_to_hwnd(window.id))
                 .context("DwmRegisterThumbnail failed")?
         };
-        update_thumbnail_rect(thumbnail, width, height);
+        let borderless = self.config.borderless;
+        update_thumbnail_rect(thumbnail, width, height, borderless);
 
         let per_window = Box::new(PreviewWindowState {
             source_id: window.id,
@@ -708,6 +739,7 @@ impl PreviewManager {
             positions: Arc::clone(&self.positions),
             drag: DragState::default(),
             is_active: false,
+            borderless,
         });
         unsafe {
             SetWindowLongPtrW(hwnd, GWLP_USERDATA, Box::into_raw(per_window) as isize);
@@ -755,9 +787,29 @@ impl PreviewManager {
 /// mirror the whole source window (including any title bar/border) — EVE's
 /// client area definition reportedly hides the actual game render surface,
 /// so SOURCECLIENTAREAONLY gives a blank preview.
-fn update_thumbnail_rect(thumbnail: Hthumbnail, width: i32, height: i32) {
+fn update_thumbnail_rect(thumbnail: Hthumbnail, width: i32, height: i32, borderless: bool) {
     let border = px(BORDER_WIDTH);
     let title = px(TITLE_HEIGHT);
+    // Borderless: no frame — the thumbnail fills the window edge-to-edge
+    // except a slim name bar at the top. DWM thumbnails always composite
+    // ON TOP of the host window's own painting, so (unlike the X11 backend)
+    // we can't float the name over the thumbnail; we reserve a thin bar for
+    // it instead. Bordered: inset by the title strip + 3px frame.
+    let rc_destination = if borderless {
+        RECT {
+            left: 0,
+            top: title,
+            right: width,
+            bottom: height,
+        }
+    } else {
+        RECT {
+            left: border,
+            top: title,
+            right: width - border,
+            bottom: height - border,
+        }
+    };
     // The thumbnail is always pushed fully opaque (255). User-facing
     // translucency is applied to the host window via apply_window_opacity;
     // scaling the thumbnail opacity instead would blend the mirror against
@@ -765,12 +817,7 @@ fn update_thumbnail_rect(thumbnail: Hthumbnail, width: i32, height: i32) {
     // rather than revealing the desktop behind.
     let props = DWM_THUMBNAIL_PROPERTIES {
         dwFlags: DWM_TNP_RECTDESTINATION | DWM_TNP_VISIBLE | DWM_TNP_OPACITY,
-        rcDestination: RECT {
-            left: border,
-            top: title,
-            right: width - border,
-            bottom: height - border,
-        },
+        rcDestination: rc_destination,
         rcSource: RECT::default(),
         opacity: 255,
         fVisible: true.into(),
@@ -817,7 +864,12 @@ unsafe extern "system" fn preview_wnd_proc(
 
     match msg {
         WM_PAINT => {
-            paint_chrome(hwnd, &state.character_name, state.is_active);
+            paint_chrome(
+                hwnd,
+                &state.character_name,
+                state.is_active,
+                state.borderless,
+            );
             LRESULT(0)
         }
         WM_LBUTTONDOWN => {
@@ -990,7 +1042,7 @@ fn nicotine_logo_font() -> HFONT {
 /// area. Border color is Nicotine red when this client is the system
 /// foreground window, otherwise the same dark color as the title strip
 /// (so it blends seamlessly).
-unsafe fn paint_chrome(hwnd: HWND, character_name: &str, is_active: bool) {
+unsafe fn paint_chrome(hwnd: HWND, character_name: &str, is_active: bool, borderless: bool) {
     let mut ps = PAINTSTRUCT::default();
     let hdc = BeginPaint(hwnd, &mut ps);
 
@@ -998,6 +1050,48 @@ unsafe fn paint_chrome(hwnd: HWND, character_name: &str, is_active: bool) {
     let _ = GetWindowRect(hwnd, &mut rect);
     let width = rect.right - rect.left;
     let height = rect.bottom - rect.top;
+
+    if borderless {
+        // No frame: just a translucent name bar at the top (whole-window
+        // alpha makes it see-through). The name turns Nicotine red when this
+        // is the active client — replacing the active border as the focus
+        // cue — and is left-aligned with a small pad to match the X11 look.
+        let title_h = px(TITLE_HEIGHT);
+        let backdrop = CreateSolidBrush(CHROME_DARK);
+        let bar = RECT {
+            left: 0,
+            top: 0,
+            right: width,
+            bottom: title_h,
+        };
+        FillRect(hdc, &bar, backdrop);
+        let _ = DeleteObject(backdrop.into());
+
+        let _ = SetBkMode(hdc, TRANSPARENT);
+        let _ = SetTextColor(
+            hdc,
+            if is_active {
+                NICOTINE_RED
+            } else {
+                COLORREF(0x00FF_FFFF)
+            },
+        );
+        let body_font = nicotine_body_font();
+        let prev_font = SelectObject(hdc, body_font.into());
+        let mut text: Vec<u16> = character_name.encode_utf16().collect();
+        // Omitting DT_CENTER left-aligns; pad the left edge by 8px.
+        let mut text_rect = RECT {
+            left: px(8),
+            top: 0,
+            right: width,
+            bottom: title_h,
+        };
+        let _ = DrawTextW(hdc, &mut text, &mut text_rect, DT_VCENTER | DT_SINGLELINE);
+        SelectObject(hdc, prev_font);
+
+        let _ = EndPaint(hwnd, &ps);
+        return;
+    }
 
     let chrome_color = if is_active { NICOTINE_RED } else { CHROME_DARK };
     let chrome_brush = CreateSolidBrush(chrome_color);

--- a/src/preview_x11/events.rs
+++ b/src/preview_x11/events.rs
@@ -6,7 +6,9 @@
 use anyhow::Result;
 
 use x11rb::protocol::damage::ConnectionExt as _;
-use x11rb::protocol::xproto::{ConfigureWindowAux, ConnectionExt as _, EventMask, GrabMode};
+use x11rb::protocol::xproto::{
+    ConfigureWindowAux, ConnectionExt as _, EventMask, GrabMode, NotifyMode,
+};
 use x11rb::protocol::Event;
 
 use crate::preview_common::{snap_position, DRAG_THRESHOLD_PX, SNAP_THRESHOLD_PX};
@@ -90,6 +92,18 @@ impl PreviewManager {
                     self.paint_list()?;
                 }
             }
+            // Pointer hover: red-highlight the preview under the cursor
+            // (red border in bordered mode, red name in borderless). Filter
+            // to NORMAL crossings so the synthetic Enter/Leave a pointer
+            // grab emits mid-drag don't flicker the highlight. These events
+            // never arrive under click-through (empty input region), so
+            // hover is inert there — as required.
+            Event::EnterNotify(ev) if ev.mode == NotifyMode::NORMAL => {
+                self.set_hover(ev.event, true)?
+            }
+            Event::LeaveNotify(ev) if ev.mode == NotifyMode::NORMAL => {
+                self.set_hover(ev.event, false)?
+            }
             // Drag lifecycle: press → motion → release. Same code paths
             // for previews and the list window — both drag identically.
             Event::ButtonPress(ev) => self.handle_button_press(ev)?,
@@ -103,6 +117,28 @@ impl PreviewManager {
             _ => {}
         }
         Ok(())
+    }
+
+    /// Set the hover highlight on the preview owning `window` and repaint
+    /// if it changed. List window has no hover highlight (no per-row
+    /// concept), so non-preview windows are ignored.
+    fn set_hover(&mut self, window: u32, hovered: bool) -> Result<()> {
+        let key = self
+            .previews
+            .iter()
+            .find(|(_, p)| p.window == window)
+            .map(|(k, _)| k.clone());
+        let Some(key) = key else {
+            return Ok(());
+        };
+        match self.previews.get_mut(&key) {
+            Some(p) if p.hovered != hovered => {
+                p.hovered = hovered;
+                p.dirty = true;
+            }
+            _ => return Ok(()),
+        }
+        self.paint_preview_now(&key)
     }
 
     /// Left-click-drag start. Grab the pointer (unless positions are

--- a/src/preview_x11/mod.rs
+++ b/src/preview_x11/mod.rs
@@ -96,6 +96,12 @@ const BORDER_WIDTH: u16 = 3;
 const TITLE_FONT_PX: f32 = 14.0;
 const TITLE_TEXT_LEFT_PAD: i16 = 10;
 
+// Borderless mode: the name is drawn over the thumbnail (no title strip),
+// so it gets a translucent black backdrop to stay legible over bright
+// content. ~60% alpha (0x9999 of 0xffff); top padding above the glyphs.
+const NAME_BACKDROP_ALPHA: u16 = 0x9999;
+const NAME_TOP_PAD: i16 = 6;
+
 // Drag / snap thresholds (DRAG_THRESHOLD_PX, SNAP_THRESHOLD_PX) live
 // in `preview_common` since both the X11 and Windows managers use
 // them. Imported above.
@@ -245,11 +251,14 @@ fn run_manager(
     // 10..=100), so the first reconcile always pushes the real value.
     let last_applied_opacity = 0u32;
 
-    // Initial display mode comes from LiveSettings (the panel's last
-    // saved choice). The first reconcile spawns the right kind of
-    // surface. We start with the same value so the first tick doesn't
-    // waste work tearing down a surface we never created.
-    let initial_mode = live.lock_recover().display_mode;
+    // Initial display mode + borderless come from LiveSettings (the
+    // panel's last saved choice). Previews are created reading the same
+    // live value, so we seed `last_applied_borderless` to match and the
+    // first reconcile doesn't do spurious relayout work.
+    let (initial_mode, initial_borderless) = {
+        let l = live.lock_recover();
+        (l.display_mode, l.borderless)
+    };
 
     let mut manager = PreviewManager {
         conn: Arc::clone(&conn),
@@ -268,6 +277,7 @@ fn run_manager(
         positions,
         last_applied_size,
         last_applied_opacity,
+        last_applied_borderless: initial_borderless,
         current_mode: initial_mode,
         list_window: None,
         needs_window_scan: true,
@@ -338,6 +348,10 @@ struct PreviewManager {
     /// against LiveSettings each reconcile so we only re-set the
     /// `_NET_WM_WINDOW_OPACITY` property when the slider actually moved.
     last_applied_opacity: u32,
+    /// Last borderless state we laid previews out for. Diffed against
+    /// LiveSettings each reconcile; on a flip we rebuild every preview's
+    /// downscale transform (the thumbnail rect changes) and repaint.
+    last_applied_borderless: bool,
     /// Whether the panel currently wants per-client previews or a
     /// single client-list window. Reconcile detects transitions and
     /// tears down the outgoing mode's surfaces before spawning the
@@ -526,6 +540,7 @@ impl PreviewManager {
         // round-trips here, so safe on every 100ms tick.
         self.apply_live_size();
         self.apply_live_opacity();
+        self.apply_live_borderless();
         // Catches the setting being toggled and previews created since
         // the last tick; the instant per-cycle response comes from the
         // same call at the end of update_active.
@@ -579,6 +594,35 @@ impl PreviewManager {
                 AtomEnum::CARDINAL,
                 &[cardinal],
             );
+        }
+    }
+
+    /// Read LiveSettings.borderless; if it flipped since the last
+    /// reconcile, rebuild each preview's downscale transform for the new
+    /// thumbnail rect (full-window vs. inset) and force a full repaint so
+    /// the chrome appears/disappears live without a daemon restart.
+    fn apply_live_borderless(&mut self) {
+        let want = self.live.lock_recover().borderless;
+        if want == self.last_applied_borderless {
+            return;
+        }
+        self.last_applied_borderless = want;
+
+        let keys: Vec<String> = self.previews.keys().cloned().collect();
+        for name in keys {
+            let (src_picture, source_w, source_h, w, h) = {
+                let Some(p) = self.previews.get(&name) else {
+                    continue;
+                };
+                (p.src_picture, p.source_w, p.source_h, p.width, p.height)
+            };
+            let (_, _, thumb_w, thumb_h) = thumbnail_rect(w, h, want);
+            let _ =
+                apply_scale_transform(&self.conn, src_picture, source_w, source_h, thumb_w, thumb_h);
+            if let Some(p) = self.previews.get_mut(&name) {
+                p.dirty = true;
+            }
+            let _ = self.paint_preview_now(&name);
         }
     }
 

--- a/src/preview_x11/preview.rs
+++ b/src/preview_x11/preview.rs
@@ -88,6 +88,13 @@ pub(super) struct OwnedPreview {
     pub(super) x: i16,
     pub(super) y: i16,
     pub(super) is_active: bool,
+    /// True while the pointer is hovering this preview. Drives the same
+    /// red highlight as `is_active` (red border in bordered mode, red
+    /// name in borderless mode). Only ever set when the window actually
+    /// receives Enter/Leave events — which it does NOT under click-through
+    /// (the input region is empty / WS_EX_TRANSPARENT), so hover is
+    /// naturally disabled there, as required.
+    pub(super) hovered: bool,
     /// True while this preview is unmapped because the "hide active
     /// client's preview" setting is on and this preview's source is the
     /// foreground client. Tracked so the reconcile/active-change passes
@@ -225,12 +232,18 @@ impl PreviewManager {
         // time the user switched clients. We keep the surface
         // present-driven instead: the render_pixmap is always fully
         // painted before we hand it to Present.
+        // ENTER_WINDOW | LEAVE_WINDOW drive the hover highlight. Under
+        // click-through these never arrive (the input region is empty), so
+        // hover is automatically inert there — which is the desired
+        // behavior: no hover highlight when click-through is on.
         let win_aux = CreateWindowAux::new()
             .event_mask(
                 EventMask::EXPOSURE
                     | EventMask::STRUCTURE_NOTIFY
                     | EventMask::BUTTON_PRESS
-                    | EventMask::BUTTON_RELEASE,
+                    | EventMask::BUTTON_RELEASE
+                    | EventMask::ENTER_WINDOW
+                    | EventMask::LEAVE_WINDOW,
             )
             .border_pixel(0)
             .override_redirect(1);
@@ -382,6 +395,7 @@ impl PreviewManager {
             x: init_x as i16,
             y: init_y as i16,
             is_active,
+            hovered: false,
             // Created mapped; the reconcile pass right after this unmaps
             // it if the hide-active setting says it should start hidden.
             hidden: false,
@@ -405,8 +419,9 @@ impl PreviewManager {
     /// character-name text on top of the strip.
     pub(super) fn paint_chrome(&self, preview: &OwnedPreview) -> Result<()> {
         let conn = &self.conn;
+        // Red when active OR hovered (hover highlight); dark otherwise.
         let chrome_color = xcolor(
-            if preview.is_active {
+            if preview.is_active || preview.hovered {
                 NICOTINE_RED
             } else {
                 CHROME_DARK
@@ -565,7 +580,7 @@ impl PreviewManager {
             src_picture,
             win_w,
             win_h,
-            is_active,
+            highlight,
             title_picture,
             title_picture_active,
             title_w,
@@ -577,7 +592,7 @@ impl PreviewManager {
                 p.src_picture,
                 p.width,
                 p.height,
-                p.is_active,
+                p.is_active || p.hovered,
                 p.title_picture,
                 p.title_picture_active,
                 p.title_text_w,
@@ -624,7 +639,8 @@ impl PreviewManager {
                     height: bd_h,
                 }],
             )?;
-            let text_picture = if is_active {
+            // Red name when active OR hovered (hover highlight), else cream.
+            let text_picture = if highlight {
                 title_picture_active
             } else {
                 title_picture

--- a/src/preview_x11/preview.rs
+++ b/src/preview_x11/preview.rs
@@ -22,13 +22,13 @@ use x11rb::wrapper::ConnectionExt as _;
 use x11rb::COPY_DEPTH_FROM_PARENT;
 
 use super::render::{
-    apply_scale_transform, create_text_pixmap, jetbrains_mono, pick_visual_format, thumbnail_size,
+    apply_scale_transform, create_text_pixmap, jetbrains_mono, pick_visual_format, thumbnail_rect,
     xcolor,
 };
 use super::{
     opacity_to_cardinal, DragState, MutexExt as _, PreviewManager, BORDER_WIDTH, CHROME_DARK,
-    NICOTINE_CREAM, NICOTINE_RED, PREVIEW_HEIGHT, PREVIEW_WIDTH, TITLE_FONT_PX, TITLE_STRIP_HEIGHT,
-    TITLE_TEXT_LEFT_PAD,
+    NAME_BACKDROP_ALPHA, NAME_TOP_PAD, NICOTINE_CREAM, NICOTINE_RED, PREVIEW_HEIGHT, PREVIEW_WIDTH,
+    TITLE_FONT_PX, TITLE_STRIP_HEIGHT, TITLE_TEXT_LEFT_PAD,
 };
 
 /// Owns one preview window's resources. Drop releases everything in
@@ -64,6 +64,11 @@ pub(super) struct OwnedPreview {
     /// baked in. Drop frees this; chrome paint composites it directly.
     pub(super) title_pixmap: u32,
     pub(super) title_picture: u32,
+    /// Second copy of the name text baked in Nicotine red instead of
+    /// cream. Used in borderless mode for the *active* client's name
+    /// (there's no red border to signal active, so the name turns red).
+    pub(super) title_pixmap_active: u32,
+    pub(super) title_picture_active: u32,
     pub(super) title_text_w: u16,
     pub(super) title_text_h: u16,
     /// Current window dimensions. Updated on live-size apply (panel
@@ -126,6 +131,8 @@ impl Drop for OwnedPreview {
         let _ = self.conn.render_free_picture(self.window_picture);
         let _ = self.conn.render_free_picture(self.title_picture);
         let _ = self.conn.free_pixmap(self.title_pixmap);
+        let _ = self.conn.render_free_picture(self.title_picture_active);
+        let _ = self.conn.free_pixmap(self.title_pixmap_active);
         let _ = self.conn.free_pixmap(self.src_pixmap);
         let _ = self
             .conn
@@ -189,12 +196,13 @@ impl PreviewManager {
         // Initial dimensions come from LiveSettings (so the panel
         // sliders' current value is honored on first spawn) falling
         // back to config and finally to the compile-time defaults.
-        let (init_w, init_h, init_opacity) = {
+        let (init_w, init_h, init_opacity, borderless) = {
             let live = self.live.lock_recover();
             (
                 live.preview_width as u16,
                 live.preview_height as u16,
                 live.preview_opacity,
+                live.borderless,
             )
         };
         let init_w = if init_w == 0 { PREVIEW_WIDTH } else { init_w };
@@ -306,6 +314,17 @@ impl PreviewManager {
             TITLE_FONT_PX,
             self.argb32_format,
         )?;
+        // Red copy of the same name for borderless mode's active client.
+        // Same glyphs/metrics as the cream copy, so we reuse its w/h.
+        let (title_pixmap_active, title_picture_active, _, _) = create_text_pixmap(
+            conn,
+            our_window,
+            title,
+            NICOTINE_RED,
+            jetbrains_mono(),
+            TITLE_FONT_PX,
+            self.argb32_format,
+        )?;
 
         // Build XRender pictures. Source wraps the redirected pixmap
         // (with a downscale transform set below). Render target is an
@@ -331,7 +350,7 @@ impl PreviewManager {
         // Transform: dest coords (within the *thumbnail* area, not the
         // full window) → source coords. Scale factors are >1 because the
         // source is larger than the thumbnail.
-        let (thumb_w, thumb_h) = thumbnail_size(init_w, init_h);
+        let (_, _, thumb_w, thumb_h) = thumbnail_rect(init_w, init_h, borderless);
         apply_scale_transform(conn, src_picture, geom.width, geom.height, thumb_w, thumb_h)?;
 
         let is_active = source_id == self.active_id;
@@ -352,6 +371,8 @@ impl PreviewManager {
             render_picture,
             title_pixmap,
             title_picture,
+            title_pixmap_active,
+            title_picture_active,
             title_text_w,
             title_text_h,
             width: init_w,
@@ -461,12 +482,12 @@ impl PreviewManager {
             Some(p) => p,
             None => return Ok(()),
         };
-        let (source_id, source_w, source_h, thumb_w, thumb_h, old_picture, old_pixmap) = (
+        let borderless = self.live.lock_recover().borderless;
+        let (_, _, thumb_w, thumb_h) = thumbnail_rect(preview.width, preview.height, borderless);
+        let (source_id, source_w, source_h, old_picture, old_pixmap) = (
             preview.source_id,
             preview.source_w,
             preview.source_h,
-            thumbnail_size(preview.width, preview.height).0,
-            thumbnail_size(preview.width, preview.height).1,
             preview.src_picture,
             preview.src_pixmap,
         );
@@ -533,51 +554,136 @@ impl PreviewManager {
     /// `window_picture` field doc for why).
     pub(super) fn paint_preview_now(&mut self, key: &str) -> Result<()> {
         self.refresh_source_pixmap(key)?;
-        let preview_snapshot = match self.previews.get(key) {
-            Some(p) => p,
+        let borderless = self.live.lock_recover().borderless;
+
+        // Snapshot the copyable handles/dims so the draw calls below don't
+        // pin a borrow of `self.previews` across the `&self` paint_chrome
+        // call or the final `&mut self` dirty-clear.
+        let (
+            render_picture,
+            window_picture,
+            src_picture,
+            win_w,
+            win_h,
+            is_active,
+            title_picture,
+            title_picture_active,
+            title_w,
+            title_h,
+        ) = match self.previews.get(key) {
+            Some(p) => (
+                p.render_picture,
+                p.window_picture,
+                p.src_picture,
+                p.width,
+                p.height,
+                p.is_active,
+                p.title_picture,
+                p.title_picture_active,
+                p.title_text_w,
+                p.title_text_h,
+            ),
             None => return Ok(()),
         };
-        // Borrow-juggling: paint_chrome takes &self, but the second half
-        // of this function takes &mut self via previews.get_mut. We do
-        // the chrome paint here with the immutable borrow, then reacquire
-        // mutably below for the composite/present.
-        self.paint_chrome(preview_snapshot)?;
-        let preview = match self.previews.get_mut(key) {
-            Some(p) => p,
-            None => return Ok(()),
-        };
-        let (thumb_w, thumb_h) = thumbnail_size(preview.width, preview.height);
-        self.conn.render_composite(
-            PictOp::SRC,
-            preview.src_picture,
-            x11rb::NONE,
-            preview.render_picture,
-            0,
-            0,
-            0,
-            0,
-            BORDER_WIDTH as i16,
-            TITLE_STRIP_HEIGHT as i16,
-            thumb_w,
-            thumb_h,
-        )?;
+
+        let (tx, ty, thumb_w, thumb_h) = thumbnail_rect(win_w, win_h, borderless);
+
+        if borderless {
+            // Thumbnail fills the whole window. PictOp::SRC overwrites any
+            // chrome pixels left from a previous bordered frame.
+            self.conn.render_composite(
+                PictOp::SRC,
+                src_picture,
+                x11rb::NONE,
+                render_picture,
+                0,
+                0,
+                0,
+                0,
+                tx,
+                ty,
+                thumb_w,
+                thumb_h,
+            )?;
+            // Translucent backdrop behind the name so it stays legible over
+            // bright thumbnails, then the name itself — red when this is the
+            // active client (no border to signal active in this mode), cream
+            // otherwise.
+            let bd_w = title_w
+                .saturating_add(2 * TITLE_TEXT_LEFT_PAD as u16)
+                .min(win_w);
+            let bd_h = title_h.saturating_add(2 * NAME_TOP_PAD as u16).min(win_h);
+            self.conn.render_fill_rectangles(
+                PictOp::OVER,
+                render_picture,
+                xcolor((0, 0, 0), NAME_BACKDROP_ALPHA),
+                &[XRectangle {
+                    x: 0,
+                    y: 0,
+                    width: bd_w,
+                    height: bd_h,
+                }],
+            )?;
+            let text_picture = if is_active {
+                title_picture_active
+            } else {
+                title_picture
+            };
+            self.conn.render_composite(
+                PictOp::OVER,
+                text_picture,
+                x11rb::NONE,
+                render_picture,
+                0,
+                0,
+                0,
+                0,
+                TITLE_TEXT_LEFT_PAD,
+                NAME_TOP_PAD,
+                title_w,
+                title_h,
+            )?;
+        } else {
+            // Chrome (title strip + colored border + cream name) first, then
+            // the thumbnail inset below the strip / inside the borders.
+            if let Some(p) = self.previews.get(key) {
+                self.paint_chrome(p)?;
+            }
+            self.conn.render_composite(
+                PictOp::SRC,
+                src_picture,
+                x11rb::NONE,
+                render_picture,
+                0,
+                0,
+                0,
+                0,
+                tx,
+                ty,
+                thumb_w,
+                thumb_h,
+            )?;
+        }
+
         // Blit the finished offscreen frame straight onto the window with one
         // composite — no X Present extension (see `window_picture`).
         self.conn.render_composite(
             PictOp::SRC,
-            preview.render_picture,
+            render_picture,
             x11rb::NONE,
-            preview.window_picture,
+            window_picture,
             0,
             0,
             0,
             0,
             0,
             0,
-            preview.width,
-            preview.height,
+            win_w,
+            win_h,
         )?;
-        preview.dirty = false;
+        if let Some(p) = self.previews.get_mut(key) {
+            p.dirty = false;
+        }
         self.conn.flush()?;
         Ok(())
     }

--- a/src/preview_x11/render.rs
+++ b/src/preview_x11/render.rs
@@ -74,6 +74,20 @@ pub(super) fn thumbnail_size(window_w: u16, window_h: u16) -> (u16, u16) {
     (w.max(1), h.max(1))
 }
 
+/// (x, y, width, height) of the thumbnail area within a preview window.
+/// In bordered mode the thumbnail is inset by the title strip (top) and
+/// the border (left/right/bottom). In borderless mode it fills the whole
+/// window edge-to-edge — the chrome is gone and the character name is
+/// drawn over the thumbnail on a translucent backdrop instead.
+pub(super) fn thumbnail_rect(window_w: u16, window_h: u16, borderless: bool) -> (i16, i16, u16, u16) {
+    if borderless {
+        (0, 0, window_w.max(1), window_h.max(1))
+    } else {
+        let (w, h) = thumbnail_size(window_w, window_h);
+        (BORDER_WIDTH as i16, TITLE_STRIP_HEIGHT as i16, w, h)
+    }
+}
+
 /// Set the source picture's transform so a thumb_w × thumb_h destination
 /// area samples the full source_w × source_h source. XRender transforms
 /// are inverse-mapping — they map dest coords to source coords — hence


### PR DESCRIPTION
- Add a **Borderless previews** setting (default off, live-toggleable): drops the title strip + colored border and renders the thumbnail edge-to-edge.
- Character name stays readable on a translucent backdrop; the **active client's name is drawn in Nicotine red** (the colour the active border uses in bordered mode).
- **Hover highlight:** hovering a preview turns its border red (bordered) or its name red (borderless), keyed on `is_active || hovered`. Naturally inert under click-through (no pointer events reach the windows).
- Implemented for X11 and Windows, plus a config-panel checkbox; takes effect live without a daemon restart.
- Windows note: DWM thumbnails composite above the host window, so the name sits in a slim translucent name bar rather than floating over the mirror.
