### PR TITLE
Click-through overlay, screen-edge snapping, and snap toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ High-performance EVE Online multiboxing tool for Linux (X11 & Wayland) and Windo
 - **Drag-to-position with snap-to-dock** on previews and the list window; lockable layout for play
 - **Multi-compositor support** — X11, KDE Plasma (Wayland), Sway, Hyprland, GNOME (Wayland; auto-stack excepted)
 - **Minimize inactive clients** — optional, reduces resource usage when cycling away
+- **Click-through overlay & edge snapping** — optionally let clicks pass through the overlay; drag-snap also snaps to screen edges (both toggleable)
 
 ## Roadmap
 - Comprehensive documentation
@@ -206,6 +207,8 @@ enable_mouse_buttons = true
 forward_button = 276       # Button 9
 backward_button = 275      # Button 8
 minimize_inactive = false  # Minimize clients when cycling away (saves resources)
+click_through = false      # Overlay ignores the mouse (input passes through)
+snapping = true            # Snap previews to each other and to screen edges
 ```
 
 Per-character jump hotkeys live under `[character_hotkeys."Name"]` with `vk` and optional `modifier`; the config panel writes them for you.

--- a/src/config.rs
+++ b/src/config.rs
@@ -54,6 +54,15 @@ pub struct LiveSettings {
     /// away from reappears. Read live so the toggle takes effect without
     /// a restart.
     pub hide_active_preview: bool,
+    /// Mirror of `config.click_through`. When true the preview/overlay
+    /// windows pass all pointer input through to whatever is behind them
+    /// (X11 empty input shape / Windows WS_EX_TRANSPARENT). Read live so
+    /// the managers can apply/clear the passthrough without a restart.
+    pub click_through: bool,
+    /// Mirror of `config.snapping`. When true, dragging a preview snaps
+    /// its edges to nearby previews and the screen edges. Read live in the
+    /// drag handlers.
+    pub snapping: bool,
 }
 
 impl LiveSettings {
@@ -66,6 +75,8 @@ impl LiveSettings {
             positions_locked: config.positions_locked,
             show_previews: config.show_previews,
             hide_active_preview: config.hide_active_preview,
+            click_through: config.click_through,
+            snapping: config.snapping,
         }))
     }
 }
@@ -120,6 +131,16 @@ pub struct Config {
     /// client.
     #[serde(default = "default_hide_active_preview")]
     pub hide_active_preview: bool,
+    /// When true, preview/overlay windows are click-through — all pointer
+    /// input passes to whatever is behind them. Default off. Live. While
+    /// on, drag / click-to-activate / hover are inert (no pointer events
+    /// reach the windows).
+    #[serde(default)]
+    pub click_through: bool,
+    /// When true (default), dragging a preview snaps its edges to nearby
+    /// previews and to the screen edges. Turn off for free placement.
+    #[serde(default = "default_snapping")]
+    pub snapping: bool,
     /// When true, the config panel locks preview width and height to a
     /// single aspect ratio and offers one "size" slider instead of
     /// separate width/height sliders. Purely a panel-side concern — the
@@ -271,6 +292,10 @@ fn default_hide_active_preview() -> bool {
     false
 }
 
+fn default_snapping() -> bool {
+    true
+}
+
 fn default_constrain_aspect() -> bool {
     false
 }
@@ -388,6 +413,8 @@ impl Config {
             preview_opacity: default_preview_opacity(),
             show_previews: default_show_previews(),
             hide_active_preview: default_hide_active_preview(),
+            click_through: false,
+            snapping: default_snapping(),
             constrain_aspect: default_constrain_aspect(),
             toggle_previews_key: None,
             toggle_previews_modifier: None,
@@ -474,6 +501,8 @@ mod tests {
             preview_opacity: 100,
             show_previews: true,
             hide_active_preview: false,
+            click_through: false,
+            snapping: true,
             constrain_aspect: false,
             toggle_previews_key: None,
             toggle_previews_modifier: None,
@@ -513,6 +542,8 @@ mod tests {
             preview_opacity: 100,
             show_previews: true,
             hide_active_preview: false,
+            click_through: false,
+            snapping: true,
             constrain_aspect: false,
             toggle_previews_key: None,
             toggle_previews_modifier: None,
@@ -551,6 +582,8 @@ mod tests {
             preview_opacity: 55,
             show_previews: true,
             hide_active_preview: true,
+            click_through: true,
+            snapping: false,
             constrain_aspect: true,
             toggle_previews_key: Some(67),
             toggle_previews_modifier: Some(42),
@@ -576,6 +609,14 @@ mod tests {
         assert!(
             deserialized.constrain_aspect,
             "constrain_aspect must survive a save/load round-trip"
+        );
+        assert!(
+            deserialized.click_through,
+            "click_through must survive a save/load round-trip"
+        );
+        assert!(
+            !deserialized.snapping,
+            "snapping must survive a save/load round-trip"
         );
         assert_eq!(
             deserialized.toggle_previews_key,

--- a/src/config_panel/mod.rs
+++ b/src/config_panel/mod.rs
@@ -408,6 +408,8 @@ pub(super) enum Message {
     KeyEvent(iced::keyboard::Event),
     ShowPreviewsToggled(bool),
     HideActivePreviewToggled(bool),
+    ClickThroughToggled(bool),
+    SnappingToggled(bool),
     ConstrainAspectToggled(bool),
     PreviewWidthChanged(u32),
     PreviewHeightChanged(u32),
@@ -570,6 +572,16 @@ fn update(panel: &mut Panel, message: Message) -> Task<Message> {
         Message::HideActivePreviewToggled(v) => {
             panel.config.hide_active_preview = v;
             panel.live.lock().unwrap().hide_active_preview = v;
+            panel.touch();
+        }
+        Message::ClickThroughToggled(v) => {
+            panel.config.click_through = v;
+            panel.live.lock().unwrap().click_through = v;
+            panel.touch();
+        }
+        Message::SnappingToggled(v) => {
+            panel.config.snapping = v;
+            panel.live.lock().unwrap().snapping = v;
             panel.touch();
         }
         Message::ConstrainAspectToggled(v) => {

--- a/src/config_panel/ui.rs
+++ b/src/config_panel/ui.rs
@@ -450,6 +450,12 @@ fn previews_section(panel: &Panel) -> Element<'_, Message> {
         checkbox(panel.config.hide_active_preview)
             .label("Hide the active client's preview")
             .on_toggle(Message::HideActivePreviewToggled),
+        checkbox(panel.config.click_through)
+            .label("Click-through (overlay ignores the mouse)")
+            .on_toggle(Message::ClickThroughToggled),
+        checkbox(panel.config.snapping)
+            .label("Snap previews to each other and screen edges")
+            .on_toggle(Message::SnappingToggled),
         checkbox(panel.config.constrain_aspect)
             .label("Constrain aspect ratio")
             .on_toggle(Message::ConstrainAspectToggled),

--- a/src/preview_common.rs
+++ b/src/preview_common.rs
@@ -109,6 +109,38 @@ pub fn snap_position(
     (x, y)
 }
 
+/// Adjust a proposed (x, y) so the dragged window's edges snap to the
+/// edges of the `screen` rect (a monitor / the virtual desktop) when
+/// within `snap_threshold`. Each axis snaps independently and the
+/// outer-edge match (left↔left, right↔right) is checked first. Applied
+/// *after* `snap_position` so window-to-window docking still wins when
+/// both could match the same axis. No-op when `snap_threshold <= 0`.
+pub fn snap_to_screen_edges(
+    proposed_x: i32,
+    proposed_y: i32,
+    width: i32,
+    height: i32,
+    screen: DragRect,
+    snap_threshold: i32,
+) -> (i32, i32) {
+    let mut x = proposed_x;
+    let mut y = proposed_y;
+    let snap = snap_threshold;
+
+    if (proposed_x - screen.left).abs() <= snap {
+        x = screen.left;
+    } else if (proposed_x + width - screen.right).abs() <= snap {
+        x = screen.right - width;
+    }
+    if (proposed_y - screen.top).abs() <= snap {
+        y = screen.top;
+    } else if (proposed_y + height - screen.bottom).abs() <= snap {
+        y = screen.bottom - height;
+    }
+
+    (x, y)
+}
+
 /// Whether a preview window should be hidden right now, given the
 /// "hide active client's preview" setting and whether this preview
 /// mirrors the currently-active EVE client.
@@ -363,6 +395,43 @@ mod tests {
         let others = [neighbor(210, 100)];
         let (x, y) = snap_position(100, 100, DRAG_W, DRAG_H, &others, 0);
         assert_eq!((x, y), (100, 100));
+    }
+
+    // 1920x1080 screen at the origin for the edge-snap tests.
+    fn screen() -> DragRect {
+        DragRect {
+            left: 0,
+            top: 0,
+            right: 1920,
+            bottom: 1080,
+        }
+    }
+
+    #[test]
+    fn edge_snaps_left_and_top() {
+        // 8px from the top-left corner — both axes snap to 0.
+        let (x, y) = snap_to_screen_edges(8, 8, DRAG_W, DRAG_H, screen(), SNAP);
+        assert_eq!((x, y), (0, 0));
+    }
+
+    #[test]
+    fn edge_snaps_right_and_bottom() {
+        // Right edge (x+100) within 12 of 1920; bottom within 12 of 1080.
+        let (x, y) = snap_to_screen_edges(1815, 975, DRAG_W, DRAG_H, screen(), SNAP);
+        assert_eq!((x, y), (1820, 980)); // x = 1920-100, y = 1080-100
+    }
+
+    #[test]
+    fn edge_no_snap_when_centered() {
+        let (x, y) = snap_to_screen_edges(900, 500, DRAG_W, DRAG_H, screen(), SNAP);
+        assert_eq!((x, y), (900, 500));
+    }
+
+    #[test]
+    fn edge_left_preferred_over_right_each_axis_independent() {
+        // Near the left edge on X, near the bottom edge on Y.
+        let (x, y) = snap_to_screen_edges(5, 975, DRAG_W, DRAG_H, screen(), SNAP);
+        assert_eq!((x, y), (0, 980));
     }
 
     #[test]

--- a/src/preview_windows/mod.rs
+++ b/src/preview_windows/mod.rs
@@ -39,7 +39,8 @@ use windows::Win32::UI::WindowsAndMessaging::{
     SM_XVIRTUALSCREEN, SM_YVIRTUALSCREEN, SWP_NOACTIVATE, SWP_NOMOVE, SWP_NOSIZE, SW_HIDE,
     SW_SHOWNOACTIVATE, WINDOW_EX_STYLE, WINEVENT_OUTOFCONTEXT, WM_DESTROY, WM_LBUTTONDOWN,
     WM_LBUTTONUP, WM_MOUSEMOVE, WM_PAINT, WM_TIMER, WNDCLASSEXW, WS_EX_LAYERED, WS_EX_NOACTIVATE,
-    WS_EX_TOOLWINDOW, WS_EX_TOPMOST, WS_EX_TRANSPARENT, WS_POPUP, WS_VISIBLE,
+    SWP_FRAMECHANGED, SWP_NOZORDER, WS_EX_TOOLWINDOW, WS_EX_TOPMOST, WS_EX_TRANSPARENT, WS_POPUP,
+    WS_VISIBLE,
 };
 
 /// Type alias for DWM thumbnail handles. windows-rs 0.59 doesn't expose a
@@ -482,9 +483,14 @@ impl PreviewManager {
             .filter(|(x, y)| position_on_screen(*x, *y))
             .unwrap_or((20, 20));
 
+        let list_click_through = if self.config.click_through {
+            WS_EX_TRANSPARENT
+        } else {
+            WINDOW_EX_STYLE(0)
+        };
         let hwnd = unsafe {
             CreateWindowExW(
-                WS_EX_TOPMOST | WS_EX_TOOLWINDOW | WS_EX_NOACTIVATE,
+                WS_EX_TOPMOST | WS_EX_TOOLWINDOW | WS_EX_NOACTIVATE | list_click_through,
                 PCWSTR(class_name.as_ptr()),
                 PCWSTR(title.as_ptr()),
                 WS_POPUP | WS_VISIBLE,
@@ -588,11 +594,27 @@ impl PreviewManager {
         }
         self.config.click_through = want;
         let bit = WS_EX_TRANSPARENT.0 as isize;
-        for preview in self.previews.values() {
+        // The list-view window is part of the overlay too.
+        let mut hwnds: Vec<HWND> = self.previews.values().map(|p| p.hwnd).collect();
+        if let Some(list) = &self.list {
+            hwnds.push(list.hwnd);
+        }
+        for hwnd in hwnds {
             unsafe {
-                let ex = GetWindowLongPtrW(preview.hwnd, GWL_EXSTYLE);
+                let ex = GetWindowLongPtrW(hwnd, GWL_EXSTYLE);
                 let new_ex = if want { ex | bit } else { ex & !bit };
-                SetWindowLongPtrW(preview.hwnd, GWL_EXSTYLE, new_ex);
+                SetWindowLongPtrW(hwnd, GWL_EXSTYLE, new_ex);
+                // An ex-style change isn't applied until a frame update;
+                // SWP_FRAMECHANGED forces it without moving/resizing/restacking.
+                let _ = SetWindowPos(
+                    hwnd,
+                    None,
+                    0,
+                    0,
+                    0,
+                    0,
+                    SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE | SWP_FRAMECHANGED,
+                );
             }
         }
     }

--- a/src/preview_windows/mod.rs
+++ b/src/preview_windows/mod.rs
@@ -1,7 +1,8 @@
 use crate::config::{Config, LiveSettings};
 use crate::cycle_state::CycleState;
 use crate::preview_common::{
-    preview_should_hide, snap_position, DragRect, DragState, DRAG_THRESHOLD_PX, SNAP_THRESHOLD_PX,
+    preview_should_hide, snap_position, snap_to_screen_edges, DragRect, DragState, DRAG_THRESHOLD_PX,
+    SNAP_THRESHOLD_PX,
 };
 use crate::window_manager::WindowManager;
 use crate::windows_manager::{hwnd_to_id, id_to_hwnd};
@@ -33,12 +34,12 @@ use windows::Win32::UI::WindowsAndMessaging::{
     CreateWindowExW, DefWindowProcW, DestroyWindow, DispatchMessageW, GetMessageW,
     GetSystemMetrics, GetWindowLongPtrW, GetWindowRect, KillTimer, LoadCursorW, RegisterClassExW,
     SetLayeredWindowAttributes, SetTimer, SetWindowLongPtrW, SetWindowPos, ShowWindow,
-    TranslateMessage, EVENT_SYSTEM_FOREGROUND, GWLP_USERDATA, HCURSOR, HICON, HMENU, HWND_TOPMOST,
-    IDC_ARROW, LWA_ALPHA, MSG, SM_CXVIRTUALSCREEN, SM_CYVIRTUALSCREEN, SM_XVIRTUALSCREEN,
-    SM_YVIRTUALSCREEN, SWP_NOACTIVATE, SWP_NOMOVE, SWP_NOSIZE, SW_HIDE, SW_SHOWNOACTIVATE,
-    WINEVENT_OUTOFCONTEXT, WM_DESTROY, WM_LBUTTONDOWN, WM_LBUTTONUP, WM_MOUSEMOVE, WM_PAINT,
-    WM_TIMER, WNDCLASSEXW, WS_EX_LAYERED, WS_EX_NOACTIVATE, WS_EX_TOOLWINDOW, WS_EX_TOPMOST,
-    WS_POPUP, WS_VISIBLE,
+    TranslateMessage, EVENT_SYSTEM_FOREGROUND, GWLP_USERDATA, GWL_EXSTYLE, HCURSOR, HICON, HMENU,
+    HWND_TOPMOST, IDC_ARROW, LWA_ALPHA, MSG, SM_CXVIRTUALSCREEN, SM_CYVIRTUALSCREEN,
+    SM_XVIRTUALSCREEN, SM_YVIRTUALSCREEN, SWP_NOACTIVATE, SWP_NOMOVE, SWP_NOSIZE, SW_HIDE,
+    SW_SHOWNOACTIVATE, WINDOW_EX_STYLE, WINEVENT_OUTOFCONTEXT, WM_DESTROY, WM_LBUTTONDOWN,
+    WM_LBUTTONUP, WM_MOUSEMOVE, WM_PAINT, WM_TIMER, WNDCLASSEXW, WS_EX_LAYERED, WS_EX_NOACTIVATE,
+    WS_EX_TOOLWINDOW, WS_EX_TOPMOST, WS_EX_TRANSPARENT, WS_POPUP, WS_VISIBLE,
 };
 
 /// Type alias for DWM thumbnail handles. windows-rs 0.59 doesn't expose a
@@ -72,6 +73,33 @@ fn positions_locked() -> bool {
         return false;
     }
     unsafe { (*ptr).live.lock().unwrap().positions_locked }
+}
+
+/// Read the shared `snapping` flag (defaults to true if the manager isn't
+/// up yet). Drag handlers consult it to decide whether to snap to other
+/// previews + screen edges.
+fn snapping_enabled() -> bool {
+    let ptr = MANAGER_PTR.load(Ordering::Acquire) as *const PreviewManager;
+    if ptr.is_null() {
+        return true;
+    }
+    unsafe { (*ptr).live.lock().unwrap().snapping }
+}
+
+/// The multi-monitor virtual desktop as a DragRect, for screen-edge snapping.
+fn virtual_screen_rect() -> DragRect {
+    unsafe {
+        let vx = GetSystemMetrics(SM_XVIRTUALSCREEN);
+        let vy = GetSystemMetrics(SM_YVIRTUALSCREEN);
+        let vw = GetSystemMetrics(SM_CXVIRTUALSCREEN);
+        let vh = GetSystemMetrics(SM_CYVIRTUALSCREEN);
+        DragRect {
+            left: vx,
+            top: vy,
+            right: vx + vw,
+            bottom: vy + vh,
+        }
+    }
 }
 
 /// WinEvent hook callback for EVENT_SYSTEM_FOREGROUND. Fires synchronously
@@ -320,6 +348,7 @@ impl PreviewManager {
         // windows resize in real time.
         self.apply_live_size();
         self.apply_live_opacity();
+        self.apply_live_click_through();
         // Catches the setting being toggled and previews created since the
         // last tick; the instant per-cycle response comes from the same
         // call at the end of update_active.
@@ -547,6 +576,27 @@ impl PreviewManager {
         }
     }
 
+    /// Read LiveSettings.click_through; if it flipped, toggle WS_EX_TRANSPARENT
+    /// on every preview so pointer input passes through (or is captured again).
+    /// New previews get the current state at creation, so this only handles the
+    /// live toggle. Caches in `self.config.click_through`, mirroring the other
+    /// apply_live_* methods.
+    fn apply_live_click_through(&mut self) {
+        let want = self.live.lock().unwrap().click_through;
+        if want == self.config.click_through {
+            return;
+        }
+        self.config.click_through = want;
+        let bit = WS_EX_TRANSPARENT.0 as isize;
+        for preview in self.previews.values() {
+            unsafe {
+                let ex = GetWindowLongPtrW(preview.hwnd, GWL_EXSTYLE);
+                let new_ex = if want { ex | bit } else { ex & !bit };
+                SetWindowLongPtrW(preview.hwnd, GWL_EXSTYLE, new_ex);
+            }
+        }
+    }
+
     /// Hide the active client's preview (and reveal everything else) when
     /// the "hide active client's preview" setting is on. Calls ShowWindow
     /// only on a state flip, so it's cheap to run every tick and on every
@@ -668,9 +718,22 @@ impl PreviewManager {
 
         let module = unsafe { GetModuleHandleW(None) }.context("GetModuleHandleW failed")?;
 
+        // WS_EX_TRANSPARENT makes the window click-through (pointer input
+        // falls through to whatever is behind it). Combined with the
+        // already-present WS_EX_LAYERED, this is the standard Win32 overlay
+        // passthrough. apply_live_click_through toggles it later.
+        let click_through_style = if self.config.click_through {
+            WS_EX_TRANSPARENT
+        } else {
+            WINDOW_EX_STYLE(0)
+        };
         let hwnd = unsafe {
             CreateWindowExW(
-                WS_EX_TOPMOST | WS_EX_TOOLWINDOW | WS_EX_NOACTIVATE | WS_EX_LAYERED,
+                WS_EX_TOPMOST
+                    | WS_EX_TOOLWINDOW
+                    | WS_EX_NOACTIVATE
+                    | WS_EX_LAYERED
+                    | click_through_style,
                 PCWSTR(class_name.as_ptr()),
                 PCWSTR(title_w.as_ptr()),
                 WS_POPUP | WS_VISIBLE,
@@ -860,25 +923,33 @@ unsafe extern "system" fn preview_wnd_proc(
                     let mut new_x = state.drag.origin_window.0 + dx;
                     let mut new_y = state.drag.origin_window.1 + dy;
 
-                    // Snap to dock with other previews if any of our edges
-                    // come within SNAP_THRESHOLD of theirs.
-                    let mut self_rect = RECT::default();
-                    if GetWindowRect(hwnd, &mut self_rect).is_ok() {
-                        let width = self_rect.right - self_rect.left;
-                        let height = self_rect.bottom - self_rect.top;
-                        let mgr_ptr = MANAGER_PTR.load(Ordering::Acquire) as *const PreviewManager;
-                        if !mgr_ptr.is_null() {
-                            let others = (*mgr_ptr).collect_other_rects(hwnd);
-                            let (sx, sy) = snap_position(
+                    // Snap to other previews + screen edges, unless snapping
+                    // is turned off in the panel.
+                    if snapping_enabled() {
+                        let mut self_rect = RECT::default();
+                        if GetWindowRect(hwnd, &mut self_rect).is_ok() {
+                            let width = self_rect.right - self_rect.left;
+                            let height = self_rect.bottom - self_rect.top;
+                            let snap = px(SNAP_THRESHOLD_PX);
+                            let mgr_ptr =
+                                MANAGER_PTR.load(Ordering::Acquire) as *const PreviewManager;
+                            if !mgr_ptr.is_null() {
+                                let others = (*mgr_ptr).collect_other_rects(hwnd);
+                                let (sx, sy) =
+                                    snap_position(new_x, new_y, width, height, &others, snap);
+                                new_x = sx;
+                                new_y = sy;
+                            }
+                            let (ex, ey) = snap_to_screen_edges(
                                 new_x,
                                 new_y,
                                 width,
                                 height,
-                                &others,
-                                px(SNAP_THRESHOLD_PX),
+                                virtual_screen_rect(),
+                                snap,
                             );
-                            new_x = sx;
-                            new_y = sy;
+                            new_x = ex;
+                            new_y = ey;
                         }
                     }
 

--- a/src/preview_x11/events.rs
+++ b/src/preview_x11/events.rs
@@ -5,11 +5,14 @@
 
 use anyhow::Result;
 
+use x11rb::connection::Connection as _;
 use x11rb::protocol::damage::ConnectionExt as _;
 use x11rb::protocol::xproto::{ConfigureWindowAux, ConnectionExt as _, EventMask, GrabMode};
 use x11rb::protocol::Event;
 
-use crate::preview_common::{snap_position, DRAG_THRESHOLD_PX, SNAP_THRESHOLD_PX};
+use crate::preview_common::{
+    snap_position, snap_to_screen_edges, DragRect, DRAG_THRESHOLD_PX, SNAP_THRESHOLD_PX,
+};
 
 use super::{DragTarget, MutexExt as _, PreviewManager};
 
@@ -236,15 +239,29 @@ impl PreviewManager {
         if !crossed_threshold {
             return Ok(());
         }
-        let others = self.collect_other_rects(&target);
-        let (snapped_x, snapped_y) = snap_position(
-            proposed_x,
-            proposed_y,
-            width as i32,
-            height as i32,
-            &others,
-            SNAP_THRESHOLD_PX,
-        );
+        // Snapping (window-to-window + screen edges) is gated by the panel
+        // toggle; when off, the window follows the cursor freely.
+        let (snapped_x, snapped_y) = if self.live.lock_recover().snapping {
+            let others = self.collect_other_rects(&target);
+            let (sx, sy) = snap_position(
+                proposed_x,
+                proposed_y,
+                width as i32,
+                height as i32,
+                &others,
+                SNAP_THRESHOLD_PX,
+            );
+            let root = &self.conn.setup().roots[self.screen_num];
+            let screen = DragRect {
+                left: 0,
+                top: 0,
+                right: root.width_in_pixels as i32,
+                bottom: root.height_in_pixels as i32,
+            };
+            snap_to_screen_edges(sx, sy, width as i32, height as i32, screen, SNAP_THRESHOLD_PX)
+        } else {
+            (proposed_x, proposed_y)
+        };
         let new_x = snapped_x.clamp(i16::MIN as i32, i16::MAX as i32) as i16;
         let new_y = snapped_y.clamp(i16::MIN as i32, i16::MAX as i32) as i16;
 

--- a/src/preview_x11/list.rs
+++ b/src/preview_x11/list.rs
@@ -213,6 +213,11 @@ impl PreviewManager {
             drag: DragState::default(),
             grabbed: false,
         });
+        // Honor click-through on the freshly-created list window (the
+        // live-apply path only fires on a *change*, so a window created
+        // while the toggle is already on would otherwise miss it).
+        let click_through = self.live.lock_recover().click_through;
+        self.set_input_passthrough(our_window, click_through);
         Ok(())
     }
 

--- a/src/preview_x11/mod.rs
+++ b/src/preview_x11/mod.rs
@@ -579,7 +579,11 @@ impl PreviewManager {
             return;
         }
         self.last_applied_click_through = want;
-        let windows: Vec<u32> = self.previews.values().map(|p| p.window).collect();
+        let mut windows: Vec<u32> = self.previews.values().map(|p| p.window).collect();
+        // The list-view window is part of the overlay too.
+        if let Some(list) = &self.list_window {
+            windows.push(list.window);
+        }
         for window in windows {
             self.set_input_passthrough(window, want);
         }

--- a/src/preview_x11/mod.rs
+++ b/src/preview_x11/mod.rs
@@ -249,7 +249,10 @@ fn run_manager(
     // saved choice). The first reconcile spawns the right kind of
     // surface. We start with the same value so the first tick doesn't
     // waste work tearing down a surface we never created.
-    let initial_mode = live.lock_recover().display_mode;
+    let (initial_mode, initial_click_through) = {
+        let l = live.lock_recover();
+        (l.display_mode, l.click_through)
+    };
 
     let mut manager = PreviewManager {
         conn: Arc::clone(&conn),
@@ -268,6 +271,7 @@ fn run_manager(
         positions,
         last_applied_size,
         last_applied_opacity,
+        last_applied_click_through: initial_click_through,
         current_mode: initial_mode,
         list_window: None,
         needs_window_scan: true,
@@ -338,6 +342,10 @@ struct PreviewManager {
     /// against LiveSettings each reconcile so we only re-set the
     /// `_NET_WM_WINDOW_OPACITY` property when the slider actually moved.
     last_applied_opacity: u32,
+    /// Last click-through state we applied to all preview windows. Diffed
+    /// against LiveSettings each reconcile so we only re-shape the input
+    /// region when the toggle actually flipped.
+    last_applied_click_through: bool,
     /// Whether the panel currently wants per-client previews or a
     /// single client-list window. Reconcile detects transitions and
     /// tears down the outgoing mode's surfaces before spawning the
@@ -526,12 +534,56 @@ impl PreviewManager {
         // round-trips here, so safe on every 100ms tick.
         self.apply_live_size();
         self.apply_live_opacity();
+        self.apply_live_click_through();
         // Catches the setting being toggled and previews created since
         // the last tick; the instant per-cycle response comes from the
         // same call at the end of update_active.
         self.apply_active_visibility();
 
         Ok(())
+    }
+
+    /// Set (or clear) input passthrough on a preview window via the X
+    /// SHAPE extension. An *empty* input shape means the window receives
+    /// no pointer events — clicks fall through to whatever is behind it.
+    /// Clearing it (NONE source bitmap) restores the default whole-window
+    /// input region.
+    pub(super) fn set_input_passthrough(&self, window: u32, passthrough: bool) {
+        use x11rb::protocol::shape::{ConnectionExt as _, SK, SO};
+        use x11rb::protocol::xproto::ClipOrdering;
+        if passthrough {
+            let _ = self.conn.shape_rectangles(
+                SO::SET,
+                SK::INPUT,
+                ClipOrdering::UNSORTED,
+                window,
+                0,
+                0,
+                &[],
+            );
+        } else {
+            let _ = self
+                .conn
+                .shape_mask(SO::SET, SK::INPUT, window, 0, 0, x11rb::NONE);
+        }
+    }
+
+    /// Read LiveSettings.click_through; if it flipped since the last
+    /// reconcile, re-shape every preview's input region so clicks either
+    /// pass through or are captured again. New previews get the current
+    /// state at creation (see create_preview), so this only handles the
+    /// live toggle.
+    fn apply_live_click_through(&mut self) {
+        let want = self.live.lock_recover().click_through;
+        if want == self.last_applied_click_through {
+            return;
+        }
+        self.last_applied_click_through = want;
+        let windows: Vec<u32> = self.previews.values().map(|p| p.window).collect();
+        for window in windows {
+            self.set_input_passthrough(window, want);
+        }
+        let _ = self.conn.flush();
     }
 
     /// Hide the active client's preview (and reveal everything else) when

--- a/src/preview_x11/preview.rs
+++ b/src/preview_x11/preview.rs
@@ -189,12 +189,13 @@ impl PreviewManager {
         // Initial dimensions come from LiveSettings (so the panel
         // sliders' current value is honored on first spawn) falling
         // back to config and finally to the compile-time defaults.
-        let (init_w, init_h, init_opacity) = {
+        let (init_w, init_h, init_opacity, click_through) = {
             let live = self.live.lock_recover();
             (
                 live.preview_width as u16,
                 live.preview_height as u16,
                 live.preview_opacity,
+                live.click_through,
             )
         };
         let init_w = if init_w == 0 { PREVIEW_WIDTH } else { init_w };
@@ -290,6 +291,11 @@ impl PreviewManager {
 
         conn.map_window(our_window)?;
         conn.sync()?;
+
+        // Honor the click-through toggle on first spawn (empty input shape =
+        // pointer events fall through). apply_live_click_through re-applies
+        // this if the toggle flips later.
+        self.set_input_passthrough(our_window, click_through);
 
         // Pre-rasterize the character name into a premultiplied-ARGB32
         // pixmap. The cream text color and per-pixel alpha are baked


### PR DESCRIPTION
- **Click-through** overlay setting (default off, live): the overlay passes all pointer input through to whatever is behind it (X11 empty SHAPE input region / Windows `WS_EX_TRANSPARENT`). While on, drag and click-to-activate are inert by design.
- **Screen-edge snapping:** dragged previews snap to the monitor / virtual-desktop edges, on top of the existing window-to-window snapping.
- **Snapping on/off toggle** (default on) gating both snap behaviours.
- Shared `snap_to_screen_edges()` helper with unit tests; two new config-panel checkboxes.
