### PR TITLE
Change the overlay toggle hotkey to an instant in-place hide

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ High-performance EVE Online multiboxing tool for Linux (X11 & Wayland) and Windo
 - **Drag-to-position with snap-to-dock** on previews and the list window; lockable layout for play
 - **Multi-compositor support** — X11, KDE Plasma (Wayland), Sway, Hyprland, GNOME (Wayland; auto-stack excepted)
 - **Minimize inactive clients** — optional, reduces resource usage when cycling away
+- **Instant overlay toggle** — bind a key to hide/show the entire overlay in place, positions preserved
 
 ## Roadmap
 - Comprehensive documentation

--- a/src/config.rs
+++ b/src/config.rs
@@ -54,6 +54,12 @@ pub struct LiveSettings {
     /// away from reappears. Read live so the toggle takes effect without
     /// a restart.
     pub hide_active_preview: bool,
+    /// Transient master "hide the whole overlay" flag, flipped by the
+    /// overlay toggle hotkey. Unlike `show_previews` (a persisted config
+    /// setting that tears the windows down), this just unmaps/hides every
+    /// overlay window in place so toggling back is instant and positions
+    /// are preserved. NOT persisted — always starts false on launch.
+    pub overlay_hidden: bool,
 }
 
 impl LiveSettings {
@@ -66,6 +72,7 @@ impl LiveSettings {
             positions_locked: config.positions_locked,
             show_previews: config.show_previews,
             hide_active_preview: config.hide_active_preview,
+            overlay_hidden: false,
         }))
     }
 }

--- a/src/config_panel/mod.rs
+++ b/src/config_panel/mod.rs
@@ -564,7 +564,14 @@ fn update(panel: &mut Panel, message: Message) -> Task<Message> {
         }
         Message::ShowPreviewsToggled(v) => {
             panel.config.show_previews = v;
-            panel.live.lock().unwrap().show_previews = v;
+            let mut live = panel.live.lock().unwrap();
+            live.show_previews = v;
+            // Re-enabling the master gate clears a stale runtime overlay-hide,
+            // so previews actually reappear instead of staying hidden.
+            if v {
+                live.overlay_hidden = false;
+            }
+            drop(live);
             panel.touch();
         }
         Message::HideActivePreviewToggled(v) => {

--- a/src/config_panel/ui.rs
+++ b/src/config_panel/ui.rs
@@ -395,7 +395,7 @@ fn hotkeys_section(panel: &Panel) -> Element<'_, Message> {
         .find(|m| m.code == panel.config.toggle_previews_modifier);
     let mut toggle_previews = bind_row(
         panel,
-        "Toggle previews:",
+        "Toggle overlay:",
         CaptureTarget::TogglePreviews,
         toggle_label,
     );

--- a/src/keyboard_listener.rs
+++ b/src/keyboard_listener.rs
@@ -228,10 +228,14 @@ impl KeyboardListener {
                 ) {
                     if event.value() == 1 {
                         let mut live = live.lock().unwrap();
-                        live.show_previews = !live.show_previews;
+                        // Instant master overlay toggle: flip the transient
+                        // overlay_hidden flag. The managers unmap/remap every
+                        // overlay window in place (no teardown), so toggling
+                        // back is instant and positions are preserved.
+                        live.overlay_hidden = !live.overlay_hidden;
                         println!(
-                            "Preview windows toggled {} via hotkey",
-                            if live.show_previews { "on" } else { "off" }
+                            "Overlay toggled {} via hotkey",
+                            if live.overlay_hidden { "hidden" } else { "shown" }
                         );
                     }
                     continue;

--- a/src/preview_windows/mod.rs
+++ b/src/preview_windows/mod.rs
@@ -554,9 +554,14 @@ impl PreviewManager {
     /// re-running this hides the newly-active preview and reshows the one
     /// cycled away from.
     fn apply_active_visibility(&mut self) {
-        let hide_active = self.live.lock().unwrap().hide_active_preview;
+        let (hide_active, overlay_hidden) = {
+            let live = self.live.lock().unwrap();
+            (live.hide_active_preview, live.overlay_hidden)
+        };
         for preview in self.previews.values_mut() {
-            let want_hidden = preview_should_hide(hide_active, preview.is_active);
+            // The master overlay toggle hides everything; otherwise fall
+            // back to the per-client "hide active" rule.
+            let want_hidden = overlay_hidden || preview_should_hide(hide_active, preview.is_active);
             if want_hidden == preview.hidden {
                 continue;
             }
@@ -570,6 +575,18 @@ impl PreviewManager {
             };
             unsafe {
                 let _ = ShowWindow(preview.hwnd, cmd);
+            }
+        }
+        // List-view window: the master toggle hides/shows it too. ShowWindow
+        // with the same state is a cheap no-op, so calling each tick is fine.
+        if let Some(list) = &self.list {
+            let cmd = if overlay_hidden {
+                SW_HIDE
+            } else {
+                SW_SHOWNOACTIVATE
+            };
+            unsafe {
+                let _ = ShowWindow(list.hwnd, cmd);
             }
         }
     }

--- a/src/preview_windows/mod.rs
+++ b/src/preview_windows/mod.rs
@@ -364,12 +364,28 @@ impl PreviewManager {
     }
 
     fn reconcile_list(&mut self) {
+        // The overlay toggle hides the list-view window too (apply_active_
+        // visibility only runs in Previews mode, so gate here for List mode).
+        if self.live.lock().unwrap().overlay_hidden {
+            if let Some(list) = &self.list {
+                unsafe {
+                    let _ = ShowWindow(list.hwnd, SW_HIDE);
+                }
+            }
+            return;
+        }
         // Spawn the list window on first entry into this mode, or if it
         // was torn down somehow.
         if self.list.is_none() {
             if let Err(e) = self.create_list_window() {
                 eprintln!("Failed to create list window: {}", e);
                 return;
+            }
+        }
+        // Re-show in case a prior overlay-hide hid it.
+        if let Some(list) = &self.list {
+            unsafe {
+                let _ = ShowWindow(list.hwnd, SW_SHOWNOACTIVATE);
             }
         }
 

--- a/src/preview_x11/list.rs
+++ b/src/preview_x11/list.rs
@@ -87,8 +87,21 @@ impl Drop for OwnedListWindow {
 
 impl PreviewManager {
     pub(super) fn reconcile_list(&mut self) -> Result<()> {
+        // The overlay toggle hides the list-view window too. apply_active_
+        // visibility only runs in Previews mode, so gate it here for List
+        // mode. Unmap (don't tear down) so toggling back is instant.
+        if self.live.lock_recover().overlay_hidden {
+            if let Some(list) = &self.list_window {
+                let _ = self.conn.unmap_window(list.window);
+            }
+            return Ok(());
+        }
         if self.list_window.is_none() {
             self.create_list_window()?;
+        }
+        // Re-map in case a prior overlay-hide unmapped it.
+        if let Some(list) = &self.list_window {
+            let _ = self.conn.map_window(list.window);
         }
         self.update_list_rows()?;
         self.paint_list()?;

--- a/src/preview_x11/mod.rs
+++ b/src/preview_x11/mod.rs
@@ -541,9 +541,14 @@ impl PreviewManager {
     /// so re-running this hides the newly-active preview and remaps the
     /// one cycled away from.
     fn apply_active_visibility(&mut self) {
-        let hide_active = self.live.lock_recover().hide_active_preview;
+        let (hide_active, overlay_hidden) = {
+            let live = self.live.lock_recover();
+            (live.hide_active_preview, live.overlay_hidden)
+        };
         for preview in self.previews.values_mut() {
-            let want_hidden = preview_should_hide(hide_active, preview.is_active);
+            // The master overlay toggle hides everything; otherwise fall
+            // back to the per-client "hide active" rule.
+            let want_hidden = overlay_hidden || preview_should_hide(hide_active, preview.is_active);
             if want_hidden == preview.hidden {
                 continue;
             }
@@ -555,6 +560,16 @@ impl PreviewManager {
                 // Backing contents are undefined after a remap; force the
                 // loop-tick repaint to re-present a complete frame.
                 preview.dirty = true;
+            }
+        }
+        // List-view window (Display Mode = List) is a single window; the
+        // master toggle hides/shows it too. map/unmap on an already-in-state
+        // window is a no-op, so this is safe to call every tick.
+        if let Some(list) = &self.list_window {
+            if overlay_hidden {
+                let _ = self.conn.unmap_window(list.window);
+            } else {
+                let _ = self.conn.map_window(list.window);
             }
         }
     }

--- a/src/windows_input.rs
+++ b/src/windows_input.rs
@@ -299,18 +299,19 @@ fn run_listener(
             continue;
         }
 
-        // Preview-visibility toggle hotkey? Flip the shared LiveSettings
-        // flag the preview manager watches; it shows/hides on the next
-        // reconcile tick, same as the panel checkbox.
+        // Overlay show/hide toggle hotkey. Flips the transient
+        // `overlay_hidden` flag the managers watch; they unmap/remap every
+        // overlay window in place on the next reconcile tick (instant,
+        // positions preserved) — matching the Linux listener.
         if msg.message == WM_HOTKEY && msg.wParam.0 as i32 == HOTKEY_TOGGLE_PREVIEWS_ID {
             let mut live_guard = live.lock().unwrap();
-            live_guard.show_previews = !live_guard.show_previews;
+            live_guard.overlay_hidden = !live_guard.overlay_hidden;
             println!(
-                "Preview windows toggled {} via hotkey",
-                if live_guard.show_previews {
-                    "on"
+                "Overlay toggled {} via hotkey",
+                if live_guard.overlay_hidden {
+                    "hidden"
                 } else {
-                    "off"
+                    "shown"
                 }
             );
             continue;


### PR DESCRIPTION
The overlay show/hide hotkey already existed (`toggle_previews_key`). This changes **how it behaves**, plus fixes that surfaced along the way.

**Functional change**
- Before: the hotkey flipped the persisted `show_previews` setting, which **tears down and respawns** every overlay window — slow, and window positions were lost.
- After: it flips a new transient `overlay_hidden` flag that the managers honor by **unmapping/hiding the windows in place**. Toggling is now instant and positions are preserved. It's independent of the persisted "Show preview windows" setting, which still works as the on-disk master gate.
- The hotkey now also hides the **list-view** window (List display mode), not just per-client previews.
- Re-enabling "Show preview windows" clears a stale runtime hide, so previews actually reappear.

**Cross-platform**
- Linux (`keyboard_listener`) and Windows (`windows_input`) both flip the new flag; X11 and Windows preview managers do the in-place hide, in both Previews and List modes.

**Panel**
- The hotkey row is relabelled "Toggle overlay".
