### PR TITLE
Gate cycling hotkeys on EVE focus

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ High-performance EVE Online multiboxing tool for Linux (X11 & Wayland) and Windo
 - **Drag-to-position with snap-to-dock** on previews and the list window; lockable layout for play
 - **Multi-compositor support** — X11, KDE Plasma (Wayland), Sway, Hyprland, GNOME (Wayland; auto-stack excepted)
 - **Minimize inactive clients** — optional, reduces resource usage when cycling away
+- **Focus-aware hotkeys** — cycling and jump keys fire only while an EVE client is focused, so they don't grab input in other apps (toggleable)
 
 ## Roadmap
 - Comprehensive documentation
@@ -206,6 +207,7 @@ enable_mouse_buttons = true
 forward_button = 276       # Button 9
 backward_button = 275      # Button 8
 minimize_inactive = false  # Minimize clients when cycling away (saves resources)
+cycle_requires_eve_focus = true  # Cycle/jump keys only fire while EVE is focused
 ```
 
 Per-character jump hotkeys live under `[character_hotkeys."Name"]` with `vk` and optional `modifier`; the config panel writes them for you.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ High-performance EVE Online multiboxing tool for Linux (X11 & Wayland) and Windo
 - **Drag-to-position with snap-to-dock** on previews and the list window; lockable layout for play
 - **Multi-compositor support** — X11, KDE Plasma (Wayland), Sway, Hyprland, GNOME (Wayland; auto-stack excepted)
 - **Minimize inactive clients** — optional, reduces resource usage when cycling away
-- **Focus-aware hotkeys** — cycling and jump keys fire only while an EVE client is focused, so they don't grab input in other apps (toggleable)
+- **Focus-aware cycling** — the cycle keys fire only while an EVE client is focused, so they don't grab input in other apps; per-character jump keys still work everywhere (toggleable)
 
 ## Roadmap
 - Comprehensive documentation
@@ -207,7 +207,7 @@ enable_mouse_buttons = true
 forward_button = 276       # Button 9
 backward_button = 275      # Button 8
 minimize_inactive = false  # Minimize clients when cycling away (saves resources)
-cycle_requires_eve_focus = true  # Cycle/jump keys only fire while EVE is focused
+cycle_requires_eve_focus = true  # Cycle keys only fire while EVE is focused
 ```
 
 Per-character jump hotkeys live under `[character_hotkeys."Name"]` with `vk` and optional `modifier`; the config panel writes them for you.

--- a/src/config.rs
+++ b/src/config.rs
@@ -95,6 +95,12 @@ pub struct Config {
     pub mouse_device_path: Option<String>,
     #[serde(default = "default_minimize_inactive")]
     pub minimize_inactive: bool,
+    /// When true (default), cycling + per-character switch hotkeys only fire
+    /// while an EVE client is the focused window, so they don't grab inputs
+    /// meant for other applications (a browser, etc.). Turn off to make the
+    /// cycle keys global again.
+    #[serde(default = "default_cycle_requires_eve_focus")]
+    pub cycle_requires_eve_focus: bool,
     #[serde(default = "default_keyboard_device_path")]
     pub keyboard_device_path: Option<String>,
     #[serde(default = "default_modifier_key")]
@@ -243,6 +249,10 @@ fn default_minimize_inactive() -> bool {
     false
 }
 
+fn default_cycle_requires_eve_focus() -> bool {
+    true
+}
+
 fn default_keyboard_device_path() -> Option<String> {
     None
 }
@@ -381,6 +391,7 @@ impl Config {
             mouse_device_name: default_mouse_device_name(),
             mouse_device_path: default_mouse_device_path(),
             minimize_inactive: default_minimize_inactive(),
+            cycle_requires_eve_focus: default_cycle_requires_eve_focus(),
             keyboard_device_path: default_keyboard_device_path(),
             modifier_key: default_modifier_key(),
             preview_width: default_preview_width(),
@@ -467,6 +478,7 @@ mod tests {
             mouse_device_name: None,
             mouse_device_path: None,
             minimize_inactive: false,
+            cycle_requires_eve_focus: true,
             keyboard_device_path: None,
             modifier_key: None,
             preview_width: 320,
@@ -506,6 +518,7 @@ mod tests {
             mouse_device_name: None,
             mouse_device_path: None,
             minimize_inactive: false,
+            cycle_requires_eve_focus: true,
             keyboard_device_path: None,
             modifier_key: None,
             preview_width: 320,
@@ -544,6 +557,7 @@ mod tests {
             mouse_device_name: None,
             mouse_device_path: None,
             minimize_inactive: false,
+            cycle_requires_eve_focus: false,
             keyboard_device_path: None,
             modifier_key: None,
             preview_width: 320,
@@ -569,6 +583,10 @@ mod tests {
         // Non-default on purpose: proves the value is actually persisted,
         // not silently masked by the serde default on load.
         assert_eq!(deserialized.preview_opacity, 55);
+        assert!(
+            !deserialized.cycle_requires_eve_focus,
+            "cycle_requires_eve_focus must survive a save/load round-trip"
+        );
         assert!(
             deserialized.hide_active_preview,
             "hide_active_preview must survive a save/load round-trip"

--- a/src/config.rs
+++ b/src/config.rs
@@ -95,10 +95,11 @@ pub struct Config {
     pub mouse_device_path: Option<String>,
     #[serde(default = "default_minimize_inactive")]
     pub minimize_inactive: bool,
-    /// When true (default), cycling + per-character switch hotkeys only fire
-    /// while an EVE client is the focused window, so they don't grab inputs
-    /// meant for other applications (a browser, etc.). Turn off to make the
-    /// cycle keys global again.
+    /// When true (default), the forward/backward cycle keys only fire while
+    /// an EVE client is the focused window, so they don't grab inputs meant
+    /// for other applications (a browser, etc.). Per-character jump keys are
+    /// unaffected — they target a specific client and work from anywhere.
+    /// Turn off to make the cycle keys global again.
     #[serde(default = "default_cycle_requires_eve_focus")]
     pub cycle_requires_eve_focus: bool,
     #[serde(default = "default_keyboard_device_path")]

--- a/src/config_panel/mod.rs
+++ b/src/config_panel/mod.rs
@@ -395,6 +395,7 @@ pub(super) enum Message {
     CharacterModifierChanged(String, ModifierChoice),
     ClearCharacterHotkey(String),
     KeyboardEnabledToggled(bool),
+    CycleRequiresEveFocusToggled(bool),
     MouseEnabledToggled(bool),
     ClearModifier,
     ClearTogglePreviews,
@@ -496,6 +497,10 @@ fn update(panel: &mut Panel, message: Message) -> Task<Message> {
         }
         Message::KeyboardEnabledToggled(v) => {
             panel.config.enable_keyboard_buttons = v;
+            panel.touch();
+        }
+        Message::CycleRequiresEveFocusToggled(v) => {
+            panel.config.cycle_requires_eve_focus = v;
             panel.touch();
         }
         Message::MouseEnabledToggled(v) => {

--- a/src/config_panel/ui.rs
+++ b/src/config_panel/ui.rs
@@ -421,8 +421,9 @@ fn hotkeys_section(panel: &Panel) -> Element<'_, Message> {
             .label("Only cycle while an EVE client is focused")
             .on_toggle(Message::CycleRequiresEveFocusToggled),
         caption(
-            "Keeps the cycle and per-character keys from firing (and grabbing input) while \
-             another application is focused. Recommended on."
+            "Keeps the forward/backward cycle keys from firing (and grabbing input) while \
+             another application is focused. Per-character jump keys still work everywhere. \
+             Recommended on."
         ),
         forward,
         backward,

--- a/src/config_panel/ui.rs
+++ b/src/config_panel/ui.rs
@@ -417,6 +417,13 @@ fn hotkeys_section(panel: &Panel) -> Element<'_, Message> {
         checkbox(panel.config.enable_keyboard_buttons)
             .label("Enable keyboard cycling")
             .on_toggle(Message::KeyboardEnabledToggled),
+        checkbox(panel.config.cycle_requires_eve_focus)
+            .label("Only cycle while an EVE client is focused")
+            .on_toggle(Message::CycleRequiresEveFocusToggled),
+        caption(
+            "Keeps the cycle and per-character keys from firing (and grabbing input) while \
+             another application is focused. Recommended on."
+        ),
         forward,
         backward,
         modifier,

--- a/src/keyboard_listener.rs
+++ b/src/keyboard_listener.rs
@@ -240,22 +240,21 @@ impl KeyboardListener {
                 }
 
                 // Resolve a possible per-character target up front (cheap
-                // hashmap lookup) so the focus gate can cover both cycling
-                // and character switching with a single check.
+                // hashmap lookup).
                 let char_target =
                     resolve_character_hotkey(code, &pressed_modifiers, &snap.character_hotkeys);
                 let is_cycle_key =
                     snap.enable && (code == snap.forward_key || code == snap.backward_key);
 
-                // Cycling + character hotkeys only act while an EVE client is
-                // focused (unless the user turned the gate off), so they don't
-                // grab inputs meant for other applications. Query focus only
-                // when the key is actually one of ours — avoids a window
-                // round-trip on every keystroke.
-                if (is_cycle_key || char_target.is_some())
-                    && snap.cycle_requires_eve_focus
-                    && !wm.focus_is_eve()
-                {
+                // Cycling only makes sense relative to the active client, so
+                // the cycle keys act only while an EVE client is focused
+                // (unless the user turned the gate off) — that's what stops
+                // them grabbing input meant for other applications. The
+                // per-character jump keys are NOT gated: they target a
+                // specific client and should work from anywhere. Focus is
+                // queried only for a cycle key, so there's no per-keystroke
+                // round-trip.
+                if is_cycle_key && snap.cycle_requires_eve_focus && !wm.focus_is_eve() {
                     continue;
                 }
 

--- a/src/keyboard_listener.rs
+++ b/src/keyboard_listener.rs
@@ -23,6 +23,7 @@ pub struct KeyboardConfig {
     pub modifier_key: Option<u16>,
     pub keyboard_device_path: Option<String>,
     pub minimize_inactive: bool,
+    pub cycle_requires_eve_focus: bool,
     pub character_hotkeys: HashMap<String, CharacterHotkey>,
     pub toggle_previews_key: Option<u16>,
     pub toggle_previews_modifier: Option<u16>,
@@ -37,6 +38,7 @@ impl KeyboardConfig {
             modifier_key: c.modifier_key,
             keyboard_device_path: c.keyboard_device_path.clone(),
             minimize_inactive: c.minimize_inactive,
+            cycle_requires_eve_focus: c.cycle_requires_eve_focus,
             character_hotkeys: c.character_hotkeys.clone(),
             toggle_previews_key: c.toggle_previews_key,
             toggle_previews_modifier: c.toggle_previews_modifier,
@@ -237,6 +239,26 @@ impl KeyboardListener {
                     continue;
                 }
 
+                // Resolve a possible per-character target up front (cheap
+                // hashmap lookup) so the focus gate can cover both cycling
+                // and character switching with a single check.
+                let char_target =
+                    resolve_character_hotkey(code, &pressed_modifiers, &snap.character_hotkeys);
+                let is_cycle_key =
+                    snap.enable && (code == snap.forward_key || code == snap.backward_key);
+
+                // Cycling + character hotkeys only act while an EVE client is
+                // focused (unless the user turned the gate off), so they don't
+                // grab inputs meant for other applications. Query focus only
+                // when the key is actually one of ours — avoids a window
+                // round-trip on every keystroke.
+                if (is_cycle_key || char_target.is_some())
+                    && snap.cycle_requires_eve_focus
+                    && !wm.focus_is_eve()
+                {
+                    continue;
+                }
+
                 // Modifier+backward must be checked first so the
                 // same-key (Tab + Shift+Tab) pattern works. Skip the
                 // whole cycling block when the user has cycling
@@ -267,9 +289,7 @@ impl KeyboardListener {
                     }
                 }
 
-                let target =
-                    resolve_character_hotkey(code, &pressed_modifiers, &snap.character_hotkeys);
-                if let Some(name) = target {
+                if let Some(name) = char_target {
                     if let Err(e) =
                         Self::switch_to_character(&name, &wm, &state, snap.minimize_inactive)
                     {
@@ -564,6 +584,7 @@ mod tests {
             modifier_key: None,
             keyboard_device_path: None,
             minimize_inactive: false,
+            cycle_requires_eve_focus: true,
             character_hotkeys: HashMap::new(),
             toggle_previews_key: None,
             toggle_previews_modifier: None,

--- a/src/window_manager.rs
+++ b/src/window_manager.rs
@@ -21,6 +21,29 @@ pub trait WindowManager: Send + Sync {
     /// Get the currently active window ID
     fn get_active_window(&self) -> Result<u32>;
 
+    /// Whether the currently-focused window belongs to an EVE client.
+    ///
+    /// Used to gate cycling/character hotkeys so they don't fire while some
+    /// other application is focused and grab inputs meant for it. The
+    /// default checks that the active window is one of our EVE windows
+    /// (both queried from the same backend, so the ids are comparable).
+    ///
+    /// Fails *open* (returns true) if focus can't be determined, so cycling
+    /// never silently dies on a transient query error. Nicotine's own
+    /// overlay windows are no-activate / click-through and never hold focus,
+    /// so "EVE focused" is the practical condition; cycling while the config
+    /// panel is focused is intentionally inert (you're configuring, not
+    /// flying).
+    fn focus_is_eve(&self) -> bool {
+        let Ok(active) = self.get_active_window() else {
+            return true;
+        };
+        match self.get_eve_windows() {
+            Ok(windows) => windows.iter().any(|w| w.id == active),
+            Err(_) => true,
+        }
+    }
+
     /// Minimize a window
     fn minimize_window(&self, window_id: u32) -> Result<()>;
 

--- a/src/window_manager.rs
+++ b/src/window_manager.rs
@@ -23,8 +23,9 @@ pub trait WindowManager: Send + Sync {
 
     /// Whether the currently-focused window belongs to an EVE client.
     ///
-    /// Used to gate cycling/character hotkeys so they don't fire while some
-    /// other application is focused and grab inputs meant for it. The
+    /// Used to gate the forward/backward cycle keys so they don't fire while
+    /// another application is focused and grab inputs meant for it (the
+    /// per-character jump keys are never gated). The
     /// default checks that the active window is one of our EVE windows
     /// (both queried from the same backend, so the ids are comparable).
     ///

--- a/src/windows_input.rs
+++ b/src/windows_input.rs
@@ -291,6 +291,19 @@ fn run_listener(
         };
         if let Some(direction) = cycle {
             debug_input(format_args!("listener: cycle direction={:?}", direction));
+            // Focus gate: keyboard cycle hotkeys only fire while an EVE
+            // client is focused (so Tab/F-keys don't grab input in other
+            // apps). Mouse-button cycling and the per-character jump keys
+            // are not gated. Read the setting fresh so the toggle applies
+            // without a restart.
+            if msg.message == WM_HOTKEY
+                && Config::load()
+                    .map(|c| c.cycle_requires_eve_focus)
+                    .unwrap_or(true)
+                && !wm.focus_is_eve()
+            {
+                continue;
+            }
             let minimize_inactive = minimize_inactive_lookup();
             match perform_cycle(&wm, &state, direction, minimize_inactive) {
                 Ok(()) => debug_input(format_args!("listener: perform_cycle OK")),


### PR DESCRIPTION
- Cycling and per-character switch hotkeys now only fire while an **EVE client is the focused window**, so they don't grab inputs meant for other applications (e.g. pressing Tab in a browser no longer cycles clients).
- New `WindowManager::focus_is_eve()` default method (active window is one of our EVE windows; same-backend ids). Fails open on a query error so cycling never silently dies; focus is queried only when a relevant key is pressed (no per-keystroke round-trip).
- Config toggle `cycle_requires_eve_focus` (default on) as an escape hatch, plus a config-panel checkbox.
- Nicotine's own overlay windows are no-activate / click-through and never hold focus, so "EVE focused" is the practical condition.
