### PR TITLE
Smart hide: occlusion-based overlay visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ forward_button = 276       # Button 9
 backward_button = 275      # Button 8
 minimize_inactive = false  # Minimize clients when cycling away (saves resources)
 smart_hide = false         # Hide the overlay unless an EVE window is mostly visible
+                           # (X11/XWayland windows only; native-Wayland occluders aren't seen)
 ```
 
 Per-character jump hotkeys live under `[character_hotkeys."Name"]` with `vk` and optional `modifier`; the config panel writes them for you.

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ High-performance EVE Online multiboxing tool for Linux (X11 & Wayland) and Windo
 - **Drag-to-position with snap-to-dock** on previews and the list window; lockable layout for play
 - **Multi-compositor support** — X11, KDE Plasma (Wayland), Sway, Hyprland, GNOME (Wayland; auto-stack excepted)
 - **Minimize inactive clients** — optional, reduces resource usage when cycling away
+- **Smart hide** — show the overlay only while at least one EVE window is ≥90% visible (occlusion-aware)
 
 ## Roadmap
 - Comprehensive documentation
@@ -206,6 +207,7 @@ enable_mouse_buttons = true
 forward_button = 276       # Button 9
 backward_button = 275      # Button 8
 minimize_inactive = false  # Minimize clients when cycling away (saves resources)
+smart_hide = false         # Hide the overlay unless an EVE window is mostly visible
 ```
 
 Per-character jump hotkeys live under `[character_hotkeys."Name"]` with `vk` and optional `modifier`; the config panel writes them for you.

--- a/src/config.rs
+++ b/src/config.rs
@@ -54,6 +54,10 @@ pub struct LiveSettings {
     /// away from reappears. Read live so the toggle takes effect without
     /// a restart.
     pub hide_active_preview: bool,
+    /// Mirror of `config.smart_hide`. When true the overlay only shows
+    /// while some EVE window is ≥90% visible (not buried behind other
+    /// apps); read live by the preview managers' occlusion check.
+    pub smart_hide: bool,
 }
 
 impl LiveSettings {
@@ -66,6 +70,7 @@ impl LiveSettings {
             positions_locked: config.positions_locked,
             show_previews: config.show_previews,
             hide_active_preview: config.hide_active_preview,
+            smart_hide: config.smart_hide,
         }))
     }
 }
@@ -120,6 +125,12 @@ pub struct Config {
     /// client.
     #[serde(default = "default_hide_active_preview")]
     pub hide_active_preview: bool,
+    /// When true, the overlay is shown only while at least one EVE window
+    /// is ≥90% visible (occlusion detection): if every EVE client is buried
+    /// behind other applications, the previews hide themselves. Default off.
+    /// Includes the pre-login EVE window (no character name yet). Live.
+    #[serde(default)]
+    pub smart_hide: bool,
     /// When true, the config panel locks preview width and height to a
     /// single aspect ratio and offers one "size" slider instead of
     /// separate width/height sliders. Purely a panel-side concern — the
@@ -388,6 +399,7 @@ impl Config {
             preview_opacity: default_preview_opacity(),
             show_previews: default_show_previews(),
             hide_active_preview: default_hide_active_preview(),
+            smart_hide: false,
             constrain_aspect: default_constrain_aspect(),
             toggle_previews_key: None,
             toggle_previews_modifier: None,
@@ -474,6 +486,7 @@ mod tests {
             preview_opacity: 100,
             show_previews: true,
             hide_active_preview: false,
+            smart_hide: false,
             constrain_aspect: false,
             toggle_previews_key: None,
             toggle_previews_modifier: None,
@@ -513,6 +526,7 @@ mod tests {
             preview_opacity: 100,
             show_previews: true,
             hide_active_preview: false,
+            smart_hide: false,
             constrain_aspect: false,
             toggle_previews_key: None,
             toggle_previews_modifier: None,
@@ -551,6 +565,7 @@ mod tests {
             preview_opacity: 55,
             show_previews: true,
             hide_active_preview: true,
+            smart_hide: true,
             constrain_aspect: true,
             toggle_previews_key: Some(67),
             toggle_previews_modifier: Some(42),
@@ -572,6 +587,10 @@ mod tests {
         assert!(
             deserialized.hide_active_preview,
             "hide_active_preview must survive a save/load round-trip"
+        );
+        assert!(
+            deserialized.smart_hide,
+            "smart_hide must survive a save/load round-trip"
         );
         assert!(
             deserialized.constrain_aspect,

--- a/src/config_panel/mod.rs
+++ b/src/config_panel/mod.rs
@@ -408,6 +408,7 @@ pub(super) enum Message {
     KeyEvent(iced::keyboard::Event),
     ShowPreviewsToggled(bool),
     HideActivePreviewToggled(bool),
+    SmartHideToggled(bool),
     ConstrainAspectToggled(bool),
     PreviewWidthChanged(u32),
     PreviewHeightChanged(u32),
@@ -570,6 +571,11 @@ fn update(panel: &mut Panel, message: Message) -> Task<Message> {
         Message::HideActivePreviewToggled(v) => {
             panel.config.hide_active_preview = v;
             panel.live.lock().unwrap().hide_active_preview = v;
+            panel.touch();
+        }
+        Message::SmartHideToggled(v) => {
+            panel.config.smart_hide = v;
+            panel.live.lock().unwrap().smart_hide = v;
             panel.touch();
         }
         Message::ConstrainAspectToggled(v) => {

--- a/src/config_panel/ui.rs
+++ b/src/config_panel/ui.rs
@@ -450,6 +450,9 @@ fn previews_section(panel: &Panel) -> Element<'_, Message> {
         checkbox(panel.config.hide_active_preview)
             .label("Hide the active client's preview")
             .on_toggle(Message::HideActivePreviewToggled),
+        checkbox(panel.config.smart_hide)
+            .label("Smart hide (only show while an EVE window is visible)")
+            .on_toggle(Message::SmartHideToggled),
         checkbox(panel.config.constrain_aspect)
             .label("Constrain aspect ratio")
             .on_toggle(Message::ConstrainAspectToggled),

--- a/src/preview_common.rs
+++ b/src/preview_common.rs
@@ -109,6 +109,82 @@ pub fn snap_position(
     (x, y)
 }
 
+/// Fraction (0.0–1.0) of `target`'s area that is NOT covered by the union
+/// of `occluders`. Occluders are clipped to `target`, then their union area
+/// is computed exactly by coordinate compression (x-sweep + y-interval
+/// merge). A zero-area target counts as fully visible (1.0).
+///
+/// Used by "smart hide": the overlay only shows when some EVE window is at
+/// least ~90% visible, i.e. `visible_fraction(eve, occluders) >= 0.90`.
+pub fn visible_fraction(target: DragRect, occluders: &[DragRect]) -> f64 {
+    let tw = (target.right - target.left).max(0) as i64;
+    let th = (target.bottom - target.top).max(0) as i64;
+    let area = tw * th;
+    if area == 0 {
+        return 1.0;
+    }
+
+    // Clip each occluder to the target; drop non-overlapping ones.
+    let clipped: Vec<DragRect> = occluders
+        .iter()
+        .filter_map(|o| {
+            let left = o.left.max(target.left);
+            let top = o.top.max(target.top);
+            let right = o.right.min(target.right);
+            let bottom = o.bottom.min(target.bottom);
+            (right > left && bottom > top).then_some(DragRect {
+                left,
+                top,
+                right,
+                bottom,
+            })
+        })
+        .collect();
+    if clipped.is_empty() {
+        return 1.0;
+    }
+
+    // Unique x boundaries split the target into vertical strips; within each
+    // strip the covering rectangles are constant in x, so the covered height
+    // is the merged length of their y-intervals.
+    let mut xs: Vec<i32> = clipped.iter().flat_map(|r| [r.left, r.right]).collect();
+    xs.sort_unstable();
+    xs.dedup();
+
+    let mut covered: i64 = 0;
+    for win in xs.windows(2) {
+        let (x0, x1) = (win[0], win[1]);
+        let strip_w = (x1 - x0) as i64;
+        if strip_w == 0 {
+            continue;
+        }
+        let mut ys: Vec<(i32, i32)> = clipped
+            .iter()
+            .filter(|r| r.left <= x0 && r.right >= x1)
+            .map(|r| (r.top, r.bottom))
+            .collect();
+        if ys.is_empty() {
+            continue;
+        }
+        ys.sort_unstable();
+        let mut merged: i64 = 0;
+        let (mut cur_top, mut cur_bot) = ys[0];
+        for &(t, b) in &ys[1..] {
+            if t > cur_bot {
+                merged += (cur_bot - cur_top) as i64;
+                cur_top = t;
+                cur_bot = b;
+            } else if b > cur_bot {
+                cur_bot = b;
+            }
+        }
+        merged += (cur_bot - cur_top) as i64;
+        covered += merged * strip_w;
+    }
+
+    ((area - covered) as f64 / area as f64).clamp(0.0, 1.0)
+}
+
 /// Whether a preview window should be hidden right now, given the
 /// "hide active client's preview" setting and whether this preview
 /// mirrors the currently-active EVE client.
@@ -363,6 +439,64 @@ mod tests {
         let others = [neighbor(210, 100)];
         let (x, y) = snap_position(100, 100, DRAG_W, DRAG_H, &others, 0);
         assert_eq!((x, y), (100, 100));
+    }
+
+    fn rect(left: i32, top: i32, right: i32, bottom: i32) -> DragRect {
+        DragRect {
+            left,
+            top,
+            right,
+            bottom,
+        }
+    }
+
+    #[test]
+    fn fully_visible_with_no_occluders() {
+        let t = rect(0, 0, 100, 100);
+        assert_eq!(visible_fraction(t, &[]), 1.0);
+    }
+
+    #[test]
+    fn fully_visible_when_occluder_does_not_overlap() {
+        let t = rect(0, 0, 100, 100);
+        assert_eq!(visible_fraction(t, &[rect(200, 200, 300, 300)]), 1.0);
+    }
+
+    #[test]
+    fn half_covered_is_half_visible() {
+        let t = rect(0, 0, 100, 100);
+        // Covers the right half (x 50..100).
+        assert!((visible_fraction(t, &[rect(50, 0, 100, 100)]) - 0.5).abs() < 1e-9);
+    }
+
+    #[test]
+    fn fully_covered_is_zero_visible() {
+        let t = rect(0, 0, 100, 100);
+        assert_eq!(visible_fraction(t, &[rect(-10, -10, 200, 200)]), 0.0);
+    }
+
+    #[test]
+    fn overlapping_occluders_not_double_counted() {
+        let t = rect(0, 0, 100, 100);
+        // Two occluders that overlap each other; union covers x 0..60 (60%).
+        let occ = [rect(0, 0, 40, 100), rect(20, 0, 60, 100)];
+        assert!((visible_fraction(t, &occ) - 0.4).abs() < 1e-9);
+    }
+
+    #[test]
+    fn small_corner_occluder_keeps_mostly_visible() {
+        let t = rect(0, 0, 100, 100);
+        // 10x10 corner = 1% covered → 99% visible (above the 90% threshold).
+        let v = visible_fraction(t, &[rect(0, 0, 10, 10)]);
+        assert!(v > 0.9, "expected >0.9, got {v}");
+    }
+
+    #[test]
+    fn occluder_clipped_to_target_before_counting() {
+        let t = rect(0, 0, 100, 100);
+        // Occluder extends well beyond target but only covers its top 10px.
+        let v = visible_fraction(t, &[rect(-50, -50, 150, 10)]);
+        assert!((v - 0.9).abs() < 1e-9, "expected 0.9, got {v}");
     }
 
     #[test]

--- a/src/preview_windows/mod.rs
+++ b/src/preview_windows/mod.rs
@@ -1,7 +1,8 @@
 use crate::config::{Config, LiveSettings};
 use crate::cycle_state::CycleState;
 use crate::preview_common::{
-    preview_should_hide, snap_position, DragRect, DragState, DRAG_THRESHOLD_PX, SNAP_THRESHOLD_PX,
+    preview_should_hide, snap_position, visible_fraction, DragRect, DragState, DRAG_THRESHOLD_PX,
+    SNAP_THRESHOLD_PX,
 };
 use crate::window_manager::WindowManager;
 use crate::windows_manager::{hwnd_to_id, id_to_hwnd};
@@ -10,9 +11,10 @@ use std::collections::HashMap;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
 use std::thread::JoinHandle;
+use std::time::{Duration, Instant};
 use windows::core::PCWSTR;
 use windows::Win32::Foundation::{
-    COLORREF, HINSTANCE, HMODULE, HWND, LPARAM, LRESULT, POINT, RECT, WPARAM,
+    BOOL, COLORREF, HINSTANCE, HMODULE, HWND, LPARAM, LRESULT, POINT, RECT, TRUE, WPARAM,
 };
 use windows::Win32::Graphics::Dwm::{
     DwmRegisterThumbnail, DwmUnregisterThumbnail, DwmUpdateThumbnailProperties,
@@ -30,8 +32,9 @@ use windows::Win32::UI::Accessibility::{SetWinEventHook, UnhookWinEvent, HWINEVE
 use windows::Win32::UI::HiDpi::GetDpiForSystem;
 use windows::Win32::UI::Input::KeyboardAndMouse::{ReleaseCapture, SetCapture};
 use windows::Win32::UI::WindowsAndMessaging::{
-    CreateWindowExW, DefWindowProcW, DestroyWindow, DispatchMessageW, GetMessageW,
-    GetSystemMetrics, GetWindowLongPtrW, GetWindowRect, KillTimer, LoadCursorW, RegisterClassExW,
+    CreateWindowExW, DefWindowProcW, DestroyWindow, DispatchMessageW, EnumWindows, GetMessageW,
+    GetSystemMetrics, GetWindowLongPtrW, GetWindowRect, GetWindowThreadProcessId, IsIconic,
+    IsWindowVisible, KillTimer, LoadCursorW, RegisterClassExW,
     SetLayeredWindowAttributes, SetTimer, SetWindowLongPtrW, SetWindowPos, ShowWindow,
     TranslateMessage, EVENT_SYSTEM_FOREGROUND, GWLP_USERDATA, HCURSOR, HICON, HMENU, HWND_TOPMOST,
     IDC_ARROW, LWA_ALPHA, MSG, SM_CXVIRTUALSCREEN, SM_CYVIRTUALSCREEN, SM_XVIRTUALSCREEN,
@@ -126,6 +129,105 @@ fn px(n: i32) -> i32 {
     (n as f32 * dpi_scale()).round() as i32
 }
 
+/// Whether `pid` is a Nicotine process (the daemon or the config panel).
+/// Used by smart-hide to exclude our own windows from the occluder set.
+/// Mirrors `eve_match::pid_is_eve_client` but matches `nicotine.exe`.
+fn pid_is_nicotine(pid: u32) -> bool {
+    use windows::core::PWSTR;
+    use windows::Win32::Foundation::CloseHandle;
+    use windows::Win32::System::Threading::{
+        OpenProcess, QueryFullProcessImageNameW, PROCESS_NAME_FORMAT,
+        PROCESS_QUERY_LIMITED_INFORMATION,
+    };
+    unsafe {
+        let Ok(handle) = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, pid) else {
+            return false;
+        };
+        let mut buf = [0u16; 1024];
+        let mut size = buf.len() as u32;
+        let ok = QueryFullProcessImageNameW(
+            handle,
+            PROCESS_NAME_FORMAT(0),
+            PWSTR(buf.as_mut_ptr()),
+            &mut size,
+        )
+        .is_ok();
+        let _ = CloseHandle(handle);
+        if !ok {
+            return false;
+        }
+        let path = String::from_utf16_lossy(&buf[..size as usize]);
+        path.rsplit(['\\', '/'])
+            .next()
+            .map(|name| name.eq_ignore_ascii_case("nicotine.exe"))
+            .unwrap_or(false)
+    }
+}
+
+/// One top-level window's smart-hide inputs, collected by EnumWindows.
+struct OcclusionWin {
+    rect: DragRect,
+    visible: bool,
+    is_eve: bool,
+    is_nicotine: bool,
+}
+
+/// EnumWindows callback: append each top-level window's occlusion info.
+/// `lparam` points at a `Vec<OcclusionWin>`. EnumWindows enumerates in
+/// Z-order, topmost first, so earlier entries are "above" later ones.
+unsafe extern "system" fn enum_collect_occlusion(hwnd: HWND, lparam: LPARAM) -> BOOL {
+    let infos = &mut *(lparam.0 as *mut Vec<OcclusionWin>);
+    let visible = IsWindowVisible(hwnd).as_bool() && !IsIconic(hwnd).as_bool();
+    let mut rect = RECT::default();
+    let has_rect = GetWindowRect(hwnd, &mut rect).is_ok();
+    let mut pid: u32 = 0;
+    GetWindowThreadProcessId(hwnd, Some(&mut pid));
+    infos.push(OcclusionWin {
+        rect: DragRect {
+            left: rect.left,
+            top: rect.top,
+            right: rect.right,
+            bottom: rect.bottom,
+        },
+        visible: visible && has_rect,
+        is_eve: pid != 0 && crate::eve_match::pid_is_eve_client(pid),
+        is_nicotine: pid != 0 && pid_is_nicotine(pid),
+    });
+    TRUE
+}
+
+/// Smart-hide occlusion check (Windows): is at least one EVE window
+/// (including the pre-login window) ≥`SMART_HIDE_THRESHOLD` visible? Walks
+/// all top-level windows top-to-bottom and, for each EVE window, measures
+/// the fraction not covered by the visible non-Nicotine windows above it.
+/// Fails *open* (true) if EnumWindows yields nothing.
+fn any_eve_visible_enough() -> bool {
+    let mut infos: Vec<OcclusionWin> = Vec::new();
+    unsafe {
+        let _ = EnumWindows(
+            Some(enum_collect_occlusion),
+            LPARAM(&mut infos as *mut _ as isize),
+        );
+    }
+    if infos.is_empty() {
+        return true;
+    }
+    for (i, info) in infos.iter().enumerate() {
+        if !info.visible || !info.is_eve {
+            continue;
+        }
+        let occluders: Vec<DragRect> = infos[..i]
+            .iter()
+            .filter(|o| o.visible && !o.is_nicotine)
+            .map(|o| o.rect)
+            .collect();
+        if visible_fraction(info.rect, &occluders) >= SMART_HIDE_THRESHOLD {
+            return true;
+        }
+    }
+    false
+}
+
 const PREVIEW_CLASS: &str = "NicotinePreviewWnd\0";
 const CONTROL_CLASS: &str = "NicotinePreviewCtrl\0";
 const LIST_CLASS: &str = "NicotineListWnd\0";
@@ -145,6 +247,14 @@ const RECONCILE_TIMER_ID: usize = 1;
 const RECONCILE_INTERVAL_MS: u32 = 100;
 const TITLE_HEIGHT: i32 = 24;
 const BORDER_WIDTH: i32 = 3;
+
+/// Smart-hide: an EVE window counts as "visible enough" to keep the overlay
+/// shown when at least this fraction of its area is unoccluded. Matches the
+/// X11 backend's threshold.
+const SMART_HIDE_THRESHOLD: f64 = 0.90;
+/// Throttle for the smart-hide EnumWindows occlusion sweep — too heavy to
+/// run on every 100ms reconcile tick.
+const SMART_HIDE_INTERVAL: Duration = Duration::from_millis(400);
 
 // DRAG_THRESHOLD_PX and SNAP_THRESHOLD_PX live in `preview_common`
 // since both managers use them. Imported above.
@@ -239,6 +349,12 @@ struct PreviewManager {
     /// InvalidateRect every 100ms otherwise produces a visible flicker
     /// and feels sluggish.
     list_last_names: Vec<String>,
+    /// Cached smart-hide occlusion result: is at least one EVE window ≥90%
+    /// visible? Recomputed on a throttle (the EnumWindows sweep is too heavy
+    /// per reconcile tick). True when smart-hide is off.
+    smart_hide_visible: bool,
+    /// Wall time of the last smart-hide occlusion check.
+    last_smart_hide_check: Instant,
 }
 
 /// Drop-guard for the list window — destroys the Win32 window and the
@@ -320,6 +436,7 @@ impl PreviewManager {
         // windows resize in real time.
         self.apply_live_size();
         self.apply_live_opacity();
+        self.refresh_smart_hide();
         // Catches the setting being toggled and previews created since the
         // last tick; the instant per-cycle response comes from the same
         // call at the end of update_active.
@@ -555,8 +672,11 @@ impl PreviewManager {
     /// cycled away from.
     fn apply_active_visibility(&mut self) {
         let hide_active = self.live.lock().unwrap().hide_active_preview;
+        // Smart-hide gate: when no EVE window is visible enough, hide the
+        // whole overlay (`smart_hide_visible` is always true when off).
+        let smart_hidden = !self.smart_hide_visible;
         for preview in self.previews.values_mut() {
-            let want_hidden = preview_should_hide(hide_active, preview.is_active);
+            let want_hidden = smart_hidden || preview_should_hide(hide_active, preview.is_active);
             if want_hidden == preview.hidden {
                 continue;
             }
@@ -571,6 +691,30 @@ impl PreviewManager {
             unsafe {
                 let _ = ShowWindow(preview.hwnd, cmd);
             }
+        }
+        // Smart-hide also gates the list-view window.
+        if let Some(list) = &self.list {
+            let cmd = if smart_hidden {
+                SW_HIDE
+            } else {
+                SW_SHOWNOACTIVATE
+            };
+            unsafe {
+                let _ = ShowWindow(list.hwnd, cmd);
+            }
+        }
+    }
+
+    /// Recompute the cached smart-hide visibility on its throttle. No-op
+    /// (resets to "visible") when smart-hide is off.
+    fn refresh_smart_hide(&mut self) {
+        if !self.live.lock().unwrap().smart_hide {
+            self.smart_hide_visible = true;
+            return;
+        }
+        if self.last_smart_hide_check.elapsed() >= SMART_HIDE_INTERVAL {
+            self.smart_hide_visible = any_eve_visible_enough();
+            self.last_smart_hide_check = Instant::now();
         }
     }
 
@@ -1412,6 +1556,8 @@ fn run_manager(
         list: None,
         active_id: 0,
         list_last_names: Vec::new(),
+        smart_hide_visible: true,
+        last_smart_hide_check: Instant::now(),
     });
     let manager_ptr = Box::into_raw(manager);
     MANAGER_PTR.store(manager_ptr as usize, Ordering::Release);

--- a/src/preview_windows/mod.rs
+++ b/src/preview_windows/mod.rs
@@ -481,12 +481,31 @@ impl PreviewManager {
     }
 
     fn reconcile_list(&mut self) {
+        // Smart-hide gates the list window too. Refresh here (it only runs
+        // from reconcile_previews otherwise, so it'd go stale in List mode)
+        // and hide when no EVE window is visible enough. `smart_hide_visible`
+        // is always true when the feature is off.
+        self.refresh_smart_hide();
+        if !self.smart_hide_visible {
+            if let Some(list) = &self.list {
+                unsafe {
+                    let _ = ShowWindow(list.hwnd, SW_HIDE);
+                }
+            }
+            return;
+        }
         // Spawn the list window on first entry into this mode, or if it
         // was torn down somehow.
         if self.list.is_none() {
             if let Err(e) = self.create_list_window() {
                 eprintln!("Failed to create list window: {}", e);
                 return;
+            }
+        }
+        // Re-show in case a prior smart-hide hid it.
+        if let Some(list) = &self.list {
+            unsafe {
+                let _ = ShowWindow(list.hwnd, SW_SHOWNOACTIVATE);
             }
         }
 

--- a/src/preview_x11/list.rs
+++ b/src/preview_x11/list.rs
@@ -87,8 +87,23 @@ impl Drop for OwnedListWindow {
 
 impl PreviewManager {
     pub(super) fn reconcile_list(&mut self) -> Result<()> {
+        // Smart-hide gates the list window too. Refresh here (it only runs
+        // from reconcile_previews otherwise, so it'd go stale in List mode)
+        // and unmap when no EVE window is visible enough. `smart_hide_visible`
+        // is always true when the feature is off, so this is a no-op then.
+        self.refresh_smart_hide();
+        if !self.smart_hide_visible {
+            if let Some(list) = &self.list_window {
+                let _ = self.conn.unmap_window(list.window);
+            }
+            return Ok(());
+        }
         if self.list_window.is_none() {
             self.create_list_window()?;
+        }
+        // Re-map in case a prior smart-hide unmapped it.
+        if let Some(list) = &self.list_window {
+            let _ = self.conn.map_window(list.window);
         }
         self.update_list_rows()?;
         self.paint_list()?;

--- a/src/preview_x11/mod.rs
+++ b/src/preview_x11/mod.rs
@@ -628,13 +628,23 @@ impl PreviewManager {
     /// windows above it — excluding Nicotine's own windows so the overlay
     /// doesn't occlude itself. Fails *open* (true) if the data is
     /// unavailable, so the overlay never gets stuck hidden.
+    ///
+    /// Limitation: under a Wayland session this only sees X11/XWayland
+    /// windows (EVE runs as XWayland, so EVE-vs-EVE and EVE-vs-other-X11
+    /// occlusion is correct), but a *native* Wayland window covering EVE is
+    /// invisible to this query — Wayland denies clients cross-surface
+    /// geometry. There it errs toward keeping the overlay shown.
     fn any_eve_visible_enough(&self) -> bool {
         let root = self.conn.setup().roots[self.screen_num].root;
         let Some(stacking) = self.read_window_stack(root) else {
             return true;
         };
+        // Fail *open* on an empty/missing stack (a WM can briefly publish an
+        // empty `_NET_CLIENT_LIST_STACKING` during transitions); hiding the
+        // whole overlay on that transient would be jarring, and it matches
+        // the Windows backend's empty-result behavior.
         if stacking.is_empty() {
-            return false;
+            return true;
         }
 
         struct WinInfo {

--- a/src/preview_x11/mod.rs
+++ b/src/preview_x11/mod.rs
@@ -38,7 +38,7 @@ use x11rb::wrapper::ConnectionExt as _;
 
 use crate::config::{Config, DisplayMode, LiveSettings};
 use crate::cycle_state::CycleState;
-use crate::preview_common::{preview_should_hide, DragRect, DragState};
+use crate::preview_common::{preview_should_hide, visible_fraction, DragRect, DragState};
 use crate::preview_positions::PreviewPositions;
 use crate::window_manager::WindowManager;
 
@@ -83,6 +83,14 @@ const WINDOW_SCAN_BACKSTOP: Duration = Duration::from_secs(2);
 /// display rate kills the "present 1 vblank too late" cadence that an
 /// exactly-60fps loop hits on a 120Hz panel.
 const FRAME_INTERVAL: Duration = Duration::from_millis(8);
+
+/// Smart-hide: an EVE window counts as "visible enough" to keep the overlay
+/// shown when at least this fraction of its area is unoccluded.
+const SMART_HIDE_THRESHOLD: f64 = 0.90;
+/// How often the smart-hide occlusion check runs. The check enumerates
+/// managed windows (geometry + pid round-trips), so it's throttled rather
+/// than run on every 100ms reconcile tick.
+const SMART_HIDE_INTERVAL: Duration = Duration::from_millis(400);
 
 // Phase 3 still hardcodes preview dimensions; Phase 4 (live size sliders)
 // will pull these from config / LiveSettings. Includes chrome — a 480×270
@@ -134,6 +142,18 @@ mod render;
 use list::OwnedListWindow;
 use preview::OwnedPreview;
 use render::*;
+
+/// Whether `pid` is a Nicotine process (the daemon or the config panel).
+/// Used by the smart-hide check to exclude our own managed windows (e.g.
+/// the config panel) from the occluder set. `/proc/<pid>/comm` is the
+/// executable's short name — the binary is `Nicotine` (with a lowercase
+/// symlink), so match case-insensitively.
+#[cfg(unix)]
+fn pid_is_nicotine(pid: u32) -> bool {
+    std::fs::read_to_string(format!("/proc/{}/comm", pid))
+        .map(|s| s.trim().eq_ignore_ascii_case("nicotine"))
+        .unwrap_or(false)
+}
 
 /// Total height of the list window for `n` character rows. Includes
 /// the 2-px gold border top and bottom, the red title strip, the
@@ -219,6 +239,7 @@ fn run_manager(
         net_wm_window_type: atom(&conn, b"_NET_WM_WINDOW_TYPE")?,
         net_wm_window_type_utility: atom(&conn, b"_NET_WM_WINDOW_TYPE_UTILITY")?,
         net_client_list: atom(&conn, b"_NET_CLIENT_LIST")?,
+        net_client_list_stacking: atom(&conn, b"_NET_CLIENT_LIST_STACKING")?,
         net_active_window: atom(&conn, b"_NET_ACTIVE_WINDOW")?,
         net_wm_pid: atom(&conn, b"_NET_WM_PID")?,
         net_wm_window_opacity: atom(&conn, b"_NET_WM_WINDOW_OPACITY")?,
@@ -272,6 +293,8 @@ fn run_manager(
         list_window: None,
         needs_window_scan: true,
         last_window_scan: Instant::now(),
+        smart_hide_visible: true,
+        last_smart_hide_check: Instant::now(),
     };
     manager.run()
 }
@@ -285,6 +308,10 @@ struct Atoms {
     net_wm_window_type: u32,
     net_wm_window_type_utility: u32,
     net_client_list: u32,
+    /// `_NET_CLIENT_LIST_STACKING` — managed windows bottom-to-top. Read
+    /// by the smart-hide occlusion check. Override-redirect windows (our
+    /// previews) aren't listed here, so they never count as occluders.
+    net_client_list_stacking: u32,
     net_active_window: u32,
     net_wm_pid: u32,
     /// `_NET_WM_WINDOW_OPACITY` — CARDINAL the compositor reads to blend
@@ -355,6 +382,13 @@ struct PreviewManager {
     /// `WINDOW_SCAN_BACKSTOP` periodic re-scan that catches EVE clients
     /// whose title only becomes "EVE - <name>" after the user logs in.
     last_window_scan: Instant,
+    /// Cached result of the smart-hide occlusion check: is at least one
+    /// EVE window ≥90% visible? Recomputed every `SMART_HIDE_INTERVAL`
+    /// (the check does geometry/pid round-trips, too costly per tick) and
+    /// read by `apply_active_visibility`. True when smart-hide is off.
+    smart_hide_visible: bool,
+    /// Wall time of the last smart-hide occlusion check.
+    last_smart_hide_check: Instant,
 }
 
 impl PreviewManager {
@@ -526,12 +560,27 @@ impl PreviewManager {
         // round-trips here, so safe on every 100ms tick.
         self.apply_live_size();
         self.apply_live_opacity();
+        self.refresh_smart_hide();
         // Catches the setting being toggled and previews created since
         // the last tick; the instant per-cycle response comes from the
         // same call at the end of update_active.
         self.apply_active_visibility();
 
         Ok(())
+    }
+
+    /// Recompute the cached smart-hide visibility on its throttle. No-op
+    /// (and resets the cache to "visible") when smart-hide is off, so the
+    /// gate never hides the overlay when the feature is disabled.
+    fn refresh_smart_hide(&mut self) {
+        if !self.live.lock_recover().smart_hide {
+            self.smart_hide_visible = true;
+            return;
+        }
+        if self.last_smart_hide_check.elapsed() >= SMART_HIDE_INTERVAL {
+            self.smart_hide_visible = self.any_eve_visible_enough();
+            self.last_smart_hide_check = Instant::now();
+        }
     }
 
     /// Hide the active client's preview (and reveal everything else) when
@@ -542,8 +591,12 @@ impl PreviewManager {
     /// one cycled away from.
     fn apply_active_visibility(&mut self) {
         let hide_active = self.live.lock_recover().hide_active_preview;
+        // Smart-hide gate: when no EVE window is visible enough, hide the
+        // whole overlay (`smart_hide_visible` is always true when the
+        // feature is off — see refresh_smart_hide).
+        let smart_hidden = !self.smart_hide_visible;
         for preview in self.previews.values_mut() {
-            let want_hidden = preview_should_hide(hide_active, preview.is_active);
+            let want_hidden = smart_hidden || preview_should_hide(hide_active, preview.is_active);
             if want_hidden == preview.hidden {
                 continue;
             }
@@ -557,6 +610,147 @@ impl PreviewManager {
                 preview.dirty = true;
             }
         }
+        // Smart-hide also gates the list-view window. map/unmap on an
+        // already-in-state window is a no-op, so calling each tick is fine.
+        if let Some(list) = &self.list_window {
+            if smart_hidden {
+                let _ = self.conn.unmap_window(list.window);
+            } else {
+                let _ = self.conn.map_window(list.window);
+            }
+        }
+    }
+
+    /// Smart-hide occlusion check: is at least one EVE window (including the
+    /// pre-login window, which has no character name) ≥`SMART_HIDE_THRESHOLD`
+    /// visible? Walks `_NET_CLIENT_LIST_STACKING` (managed windows, bottom to
+    /// top), and for each EVE window measures the fraction not covered by the
+    /// windows above it — excluding Nicotine's own windows so the overlay
+    /// doesn't occlude itself. Fails *open* (true) if the data is
+    /// unavailable, so the overlay never gets stuck hidden.
+    fn any_eve_visible_enough(&self) -> bool {
+        let root = self.conn.setup().roots[self.screen_num].root;
+        let Some(stacking) = self.read_window_stack(root) else {
+            return true;
+        };
+        if stacking.is_empty() {
+            return false;
+        }
+
+        struct WinInfo {
+            rect: DragRect,
+            viewable: bool,
+            is_eve: bool,
+            is_nicotine: bool,
+        }
+
+        // Pipeline the per-window queries: send all requests, then read all
+        // replies, so this is a few flushes rather than 4 round-trips/window.
+        let translations: Vec<_> = stacking
+            .iter()
+            .map(|&w| self.conn.translate_coordinates(w, root, 0, 0))
+            .collect();
+        let geometries: Vec<_> = stacking.iter().map(|&w| self.conn.get_geometry(w)).collect();
+        let attributes: Vec<_> = stacking
+            .iter()
+            .map(|&w| self.conn.get_window_attributes(w))
+            .collect();
+        let pids: Vec<_> = stacking
+            .iter()
+            .map(|&w| {
+                self.conn.get_property(
+                    false,
+                    w,
+                    self.atoms.net_wm_pid,
+                    AtomEnum::CARDINAL,
+                    0,
+                    1,
+                )
+            })
+            .collect();
+
+        let mut infos = Vec::with_capacity(stacking.len());
+        for (((tr, ge), at), pi) in translations
+            .into_iter()
+            .zip(geometries)
+            .zip(attributes)
+            .zip(pids)
+        {
+            let (Ok(tr), Ok(ge), Ok(at), Ok(pi)) = (
+                tr.map_err(|_| ()).and_then(|c| c.reply().map_err(|_| ())),
+                ge.map_err(|_| ()).and_then(|c| c.reply().map_err(|_| ())),
+                at.map_err(|_| ()).and_then(|c| c.reply().map_err(|_| ())),
+                pi.map_err(|_| ()).and_then(|c| c.reply().map_err(|_| ())),
+            ) else {
+                // Window vanished mid-query — treat as a non-occluding,
+                // non-EVE gap so it neither hides nor reveals the overlay.
+                infos.push(WinInfo {
+                    rect: DragRect {
+                        left: 0,
+                        top: 0,
+                        right: 0,
+                        bottom: 0,
+                    },
+                    viewable: false,
+                    is_eve: false,
+                    is_nicotine: false,
+                });
+                continue;
+            };
+            let pid = pi.value32().and_then(|mut it| it.next());
+            let (is_eve, is_nicotine) = match pid {
+                Some(p) => (crate::eve_match::pid_is_eve_client(p), pid_is_nicotine(p)),
+                None => (false, false),
+            };
+            infos.push(WinInfo {
+                rect: DragRect {
+                    left: tr.dst_x as i32,
+                    top: tr.dst_y as i32,
+                    right: tr.dst_x as i32 + ge.width as i32,
+                    bottom: tr.dst_y as i32 + ge.height as i32,
+                },
+                viewable: at.map_state == x11rb::protocol::xproto::MapState::VIEWABLE,
+                is_eve,
+                is_nicotine,
+            });
+        }
+
+        for (i, info) in infos.iter().enumerate() {
+            if !info.viewable || !info.is_eve {
+                continue;
+            }
+            // Occluders: viewable, non-Nicotine windows stacked above this
+            // one. (Our override-redirect previews aren't in the stack at
+            // all; the managed config panel is excluded via is_nicotine.)
+            let occluders: Vec<DragRect> = infos[i + 1..]
+                .iter()
+                .filter(|o| o.viewable && !o.is_nicotine)
+                .map(|o| o.rect)
+                .collect();
+            if visible_fraction(info.rect, &occluders) >= SMART_HIDE_THRESHOLD {
+                return true;
+            }
+        }
+        false
+    }
+
+    /// Read `_NET_CLIENT_LIST_STACKING` (managed windows, bottom to top).
+    fn read_window_stack(&self, root: u32) -> Option<Vec<u32>> {
+        let reply = self
+            .conn
+            .get_property(
+                false,
+                root,
+                self.atoms.net_client_list_stacking,
+                AtomEnum::WINDOW,
+                0,
+                u32::MAX,
+            )
+            .ok()?
+            .reply()
+            .ok()?;
+        let windows: Vec<u32> = reply.value32()?.collect();
+        Some(windows)
     }
 
     /// Read LiveSettings.preview_opacity; if it changed since the last


### PR DESCRIPTION
- New **Smart hide** setting (default off, live): the overlay is shown only while at least one EVE window is **≥90% visible**; it hides when every client is buried behind other apps and returns when one resurfaces.
- Includes the pre-login EVE window (detected by process, not title, so it works before a character name appears).
- Pure, unit-tested `visible_fraction()` (exact rectangle-union occlusion via coordinate compression).
- X11 walks `_NET_CLIENT_LIST_STACKING` (override-redirect previews aren't listed, so no self-occlusion feedback loop); Windows uses `EnumWindows`. Both exclude Nicotine's own windows and throttle the check to ~400ms.
- Config-panel checkbox.
- Wayland note: native-Wayland windows aren't visible to the X11 occlusion query under XWayland, so they don't count as occluders.
