### PR TITLE
Boss key: hide+mute toggle and kill-all

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ High-performance EVE Online multiboxing tool for Linux (X11 & Wayland) and Windo
 - **Drag-to-position with snap-to-dock** on previews and the list window; lockable layout for play
 - **Multi-compositor support** — X11, KDE Plasma (Wayland), Sway, Hyprland, GNOME (Wayland; auto-stack excepted)
 - **Minimize inactive clients** — optional, reduces resource usage when cycling away
+- **Boss key** — one hotkey hides + mutes every client (toggle), another force-quits all EVE + Nicotine processes
 
 ## Roadmap
 - Comprehensive documentation
@@ -206,6 +207,7 @@ enable_mouse_buttons = true
 forward_button = 276       # Button 9
 backward_button = 275      # Button 8
 minimize_inactive = false  # Minimize clients when cycling away (saves resources)
+# boss_hide_key / boss_kill_key  — emergency hotkeys, bound in the panel's Hotkeys tab
 ```
 
 Per-character jump hotkeys live under `[character_hotkeys."Name"]` with `vk` and optional `modifier`; the config panel writes them for you.

--- a/src/boss.rs
+++ b/src/boss.rs
@@ -1,0 +1,200 @@
+//! "Boss key" support: panic actions that hide or kill everything.
+//!
+//! Two modes, bound to separate hotkeys in the config:
+//!   * **Hide + mute** (a toggle): minimize every EVE client, mute their
+//!     audio, and hide the overlay. Press again to restore. Implemented in
+//!     the input listeners (which own the
+//!     window-manager handle and the live `bossed` flag); the audio + pid
+//!     helpers live here.
+//!   * **Kill all**: force-terminate every EVE client and every Nicotine
+//!     process (including this one). No confirmation — that's the point.
+//!
+//! Process matching reuses the same executable-name signal as
+//! [`crate::eve_match`]: EVE clients are `exefile.exe`; Nicotine is
+//! `Nicotine`/`nicotine` (Linux) or `nicotine.exe` (Windows).
+
+/// PIDs of all running EVE clients (`exefile.exe`), including the
+/// pre-login client.
+#[cfg(unix)]
+pub fn eve_client_pids() -> Vec<u32> {
+    pids_with_comm(|comm| comm == "exefile.exe")
+}
+
+/// PIDs of all Nicotine processes (daemon + config panel).
+#[cfg(unix)]
+pub fn nicotine_pids() -> Vec<u32> {
+    pids_with_comm(|comm| comm.eq_ignore_ascii_case("nicotine"))
+}
+
+/// Scan `/proc` for processes whose `comm` matches `pred`.
+#[cfg(unix)]
+fn pids_with_comm(pred: impl Fn(&str) -> bool) -> Vec<u32> {
+    let mut pids = Vec::new();
+    let Ok(entries) = std::fs::read_dir("/proc") else {
+        return pids;
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let Some(pid) = name.to_str().and_then(|s| s.parse::<u32>().ok()) else {
+            continue;
+        };
+        if let Ok(comm) = std::fs::read_to_string(format!("/proc/{pid}/comm")) {
+            if pred(comm.trim()) {
+                pids.push(pid);
+            }
+        }
+    }
+    pids
+}
+
+/// Force-kill every EVE client and every Nicotine process. Kills others
+/// first, then exits this process last so the remaining kills always run.
+#[cfg(unix)]
+pub fn kill_all() -> ! {
+    use nix::sys::signal::{kill, Signal};
+    use nix::unistd::Pid;
+
+    let self_pid = std::process::id();
+    let mut targets: Vec<u32> = eve_client_pids();
+    targets.extend(nicotine_pids());
+    for pid in targets {
+        if pid == self_pid {
+            continue;
+        }
+        let _ = kill(Pid::from_raw(pid as i32), Signal::SIGKILL);
+    }
+    std::process::exit(0);
+}
+
+/// Mute the PulseAudio/PipeWire sink-inputs belonging to `eve_pids`.
+/// Returns the sink-input indices we muted so [`unmute`] can restore
+/// exactly those. Best-effort: any failure (no `pactl`, no audio server,
+/// unparseable output) yields an empty list rather than an error.
+#[cfg(unix)]
+pub fn mute_eve(eve_pids: &[u32]) -> Vec<u32> {
+    let mut muted = Vec::new();
+    let Ok(output) = std::process::Command::new("pactl")
+        .args(["-f", "json", "list", "sink-inputs"])
+        .output()
+    else {
+        return muted;
+    };
+    let Ok(json) = serde_json::from_slice::<serde_json::Value>(&output.stdout) else {
+        return muted;
+    };
+    let Some(inputs) = json.as_array() else {
+        return muted;
+    };
+    for input in inputs {
+        let pid = input
+            .get("properties")
+            .and_then(|p| p.get("application.process.id"))
+            .and_then(|v| v.as_str())
+            .and_then(|s| s.parse::<u32>().ok());
+        let index = input.get("index").and_then(|v| v.as_u64());
+        if let (Some(pid), Some(index)) = (pid, index) {
+            if eve_pids.contains(&pid) {
+                let _ = std::process::Command::new("pactl")
+                    .args(["set-sink-input-mute", &index.to_string(), "1"])
+                    .status();
+                muted.push(index as u32);
+            }
+        }
+    }
+    muted
+}
+
+/// Unmute the sink-inputs previously muted by [`mute_eve`].
+#[cfg(unix)]
+pub fn unmute(sink_inputs: &[u32]) {
+    for &index in sink_inputs {
+        let _ = std::process::Command::new("pactl")
+            .args(["set-sink-input-mute", &index.to_string(), "0"])
+            .status();
+    }
+}
+
+// ---- Windows ----
+
+/// PIDs of all running EVE clients (`exefile.exe`).
+#[cfg(windows)]
+pub fn eve_client_pids() -> Vec<u32> {
+    pids_with_exe(|exe| exe.eq_ignore_ascii_case("exefile.exe"))
+}
+
+/// PIDs of all Nicotine processes.
+#[cfg(windows)]
+pub fn nicotine_pids() -> Vec<u32> {
+    pids_with_exe(|exe| exe.eq_ignore_ascii_case("nicotine.exe"))
+}
+
+/// Enumerate processes via the toolhelp snapshot, returning PIDs whose
+/// executable basename matches `pred`.
+#[cfg(windows)]
+fn pids_with_exe(pred: impl Fn(&str) -> bool) -> Vec<u32> {
+    use windows::Win32::System::Diagnostics::ToolHelp::{
+        CreateToolhelp32Snapshot, Process32FirstW, Process32NextW, PROCESSENTRY32W,
+        TH32CS_SNAPPROCESS,
+    };
+    let mut pids = Vec::new();
+    unsafe {
+        let Ok(snapshot) = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0) else {
+            return pids;
+        };
+        let mut entry = PROCESSENTRY32W {
+            dwSize: std::mem::size_of::<PROCESSENTRY32W>() as u32,
+            ..Default::default()
+        };
+        if Process32FirstW(snapshot, &mut entry).is_ok() {
+            loop {
+                let end = entry
+                    .szExeFile
+                    .iter()
+                    .position(|&c| c == 0)
+                    .unwrap_or(entry.szExeFile.len());
+                let exe = String::from_utf16_lossy(&entry.szExeFile[..end]);
+                if pred(&exe) {
+                    pids.push(entry.th32ProcessID);
+                }
+                if Process32NextW(snapshot, &mut entry).is_err() {
+                    break;
+                }
+            }
+        }
+        let _ = windows::Win32::Foundation::CloseHandle(snapshot);
+    }
+    pids
+}
+
+/// Force-kill every EVE client and every Nicotine process, then exit.
+#[cfg(windows)]
+pub fn kill_all() -> ! {
+    use windows::Win32::System::Threading::{OpenProcess, TerminateProcess, PROCESS_TERMINATE};
+    let self_pid = std::process::id();
+    let mut targets = eve_client_pids();
+    targets.extend(nicotine_pids());
+    for pid in targets {
+        if pid == self_pid {
+            continue;
+        }
+        unsafe {
+            if let Ok(handle) = OpenProcess(PROCESS_TERMINATE, false, pid) {
+                let _ = TerminateProcess(handle, 1);
+                let _ = windows::Win32::Foundation::CloseHandle(handle);
+            }
+        }
+    }
+    std::process::exit(0);
+}
+
+/// Per-application audio muting isn't wired up on Windows yet (it needs the
+/// Core Audio session API, `ISimpleAudioVolume`). The boss key still hides
+/// and minimizes clients; muting is a no-op here for now.
+#[cfg(windows)]
+pub fn mute_eve(_eve_pids: &[u32]) -> Vec<u32> {
+    Vec::new()
+}
+
+/// No-op counterpart to the Windows [`mute_eve`] stub.
+#[cfg(windows)]
+pub fn unmute(_sink_inputs: &[u32]) {}

--- a/src/config.rs
+++ b/src/config.rs
@@ -54,6 +54,11 @@ pub struct LiveSettings {
     /// away from reappears. Read live so the toggle takes effect without
     /// a restart.
     pub hide_active_preview: bool,
+    /// Transient "boss key engaged" flag. When true the overlay is hidden
+    /// (the boss-hide hotkey also minimizes + mutes the EVE clients). NOT
+    /// persisted — always starts false on launch. Restored by pressing the
+    /// boss key again.
+    pub bossed: bool,
 }
 
 impl LiveSettings {
@@ -66,6 +71,7 @@ impl LiveSettings {
             positions_locked: config.positions_locked,
             show_previews: config.show_previews,
             hide_active_preview: config.hide_active_preview,
+            bossed: false,
         }))
     }
 }
@@ -137,6 +143,19 @@ pub struct Config {
     /// `None` = no modifier (the bare key toggles).
     #[serde(default)]
     pub toggle_previews_modifier: Option<u16>,
+    /// Boss key — hide + mute. Minimizes + mutes every EVE client and hides
+    /// the overlay; press again to restore. `None` =
+    /// unbound. Bound via the panel's Hotkeys tab.
+    #[serde(default)]
+    pub boss_hide_key: Option<u16>,
+    #[serde(default)]
+    pub boss_hide_modifier: Option<u16>,
+    /// Boss key — kill all. Force-terminates every EVE client and every
+    /// Nicotine process. `None` = unbound.
+    #[serde(default)]
+    pub boss_kill_key: Option<u16>,
+    #[serde(default)]
+    pub boss_kill_modifier: Option<u16>,
     /// Ordered list of EVE character names. Forward/backward cycling
     /// traverses this order; `switch N` maps target N to entry N-1.
     /// Empty list = cycle through whatever order the window manager
@@ -391,6 +410,10 @@ impl Config {
             constrain_aspect: default_constrain_aspect(),
             toggle_previews_key: None,
             toggle_previews_modifier: None,
+            boss_hide_key: None,
+            boss_hide_modifier: None,
+            boss_kill_key: None,
+            boss_kill_modifier: None,
             characters: Vec::new(),
             display_mode: default_display_mode(),
             positions_locked: false,
@@ -477,6 +500,10 @@ mod tests {
             constrain_aspect: false,
             toggle_previews_key: None,
             toggle_previews_modifier: None,
+            boss_hide_key: None,
+            boss_hide_modifier: None,
+            boss_kill_key: None,
+            boss_kill_modifier: None,
             characters: Vec::new(),
             display_mode: DisplayMode::Previews,
             positions_locked: false,
@@ -516,6 +543,10 @@ mod tests {
             constrain_aspect: false,
             toggle_previews_key: None,
             toggle_previews_modifier: None,
+            boss_hide_key: None,
+            boss_hide_modifier: None,
+            boss_kill_key: None,
+            boss_kill_modifier: None,
             characters: Vec::new(),
             display_mode: DisplayMode::Previews,
             positions_locked: false,
@@ -554,6 +585,10 @@ mod tests {
             constrain_aspect: true,
             toggle_previews_key: Some(67),
             toggle_previews_modifier: Some(42),
+            boss_hide_key: Some(99),
+            boss_hide_modifier: None,
+            boss_kill_key: None,
+            boss_kill_modifier: None,
             characters: Vec::new(),
             display_mode: DisplayMode::Previews,
             positions_locked: false,
@@ -586,6 +621,11 @@ mod tests {
             deserialized.toggle_previews_modifier,
             Some(42),
             "toggle_previews_modifier must survive a save/load round-trip"
+        );
+        assert_eq!(
+            deserialized.boss_hide_key,
+            Some(99),
+            "boss_hide_key must survive a save/load round-trip"
         );
         assert_eq!(
             deserialized.window_width, 900,

--- a/src/config_panel/mod.rs
+++ b/src/config_panel/mod.rs
@@ -60,6 +60,8 @@ pub(super) enum CaptureTarget {
     BackwardKey,
     ModifierKey,
     TogglePreviews,
+    BossHide,
+    BossKill,
     Character(String),
 }
 
@@ -347,6 +349,8 @@ impl Panel {
                 CaptureTarget::BackwardKey => self.config.backward_key = vk,
                 CaptureTarget::ModifierKey => self.config.modifier_key = Some(vk),
                 CaptureTarget::TogglePreviews => self.config.toggle_previews_key = Some(vk),
+                CaptureTarget::BossHide => self.config.boss_hide_key = Some(vk),
+                CaptureTarget::BossKill => self.config.boss_kill_key = Some(vk),
                 CaptureTarget::Character(name) => {
                     let modifier = self
                         .config
@@ -399,6 +403,10 @@ pub(super) enum Message {
     ClearModifier,
     ClearTogglePreviews,
     TogglePreviewsModifierChanged(ModifierChoice),
+    ClearBossHide,
+    BossHideModifierChanged(ModifierChoice),
+    ClearBossKill,
+    BossKillModifierChanged(ModifierChoice),
     StartCapture(CaptureTarget),
     TabSelected(Tab),
     GrabRow(usize),
@@ -513,6 +521,24 @@ fn update(panel: &mut Panel, message: Message) -> Task<Message> {
         }
         Message::TogglePreviewsModifierChanged(choice) => {
             panel.config.toggle_previews_modifier = choice.code;
+            panel.touch();
+        }
+        Message::ClearBossHide => {
+            panel.config.boss_hide_key = None;
+            panel.config.boss_hide_modifier = None;
+            panel.touch();
+        }
+        Message::BossHideModifierChanged(choice) => {
+            panel.config.boss_hide_modifier = choice.code;
+            panel.touch();
+        }
+        Message::ClearBossKill => {
+            panel.config.boss_kill_key = None;
+            panel.config.boss_kill_modifier = None;
+            panel.touch();
+        }
+        Message::BossKillModifierChanged(choice) => {
+            panel.config.boss_kill_modifier = choice.code;
             panel.touch();
         }
         Message::StartCapture(target) => {

--- a/src/config_panel/ui.rs
+++ b/src/config_panel/ui.rs
@@ -412,6 +412,59 @@ fn hotkeys_section(panel: &Panel) -> Element<'_, Message> {
             toggle_previews.push(button(text("Clear")).on_press(Message::ClearTogglePreviews));
     }
 
+    // Boss keys — hide+mute toggle and kill-all.
+    let boss_hide_label = match panel.config.boss_hide_key {
+        Some(vk) => code_to_label(vk),
+        None => "None".to_string(),
+    };
+    let boss_hide_mod_selected = MODIFIER_CHOICES
+        .iter()
+        .copied()
+        .find(|m| m.code == panel.config.boss_hide_modifier);
+    let mut boss_hide = bind_row(
+        panel,
+        "Boss key (hide+mute):",
+        CaptureTarget::BossHide,
+        boss_hide_label,
+    );
+    boss_hide = boss_hide.push(
+        pick_list(
+            MODIFIER_CHOICES,
+            boss_hide_mod_selected,
+            Message::BossHideModifierChanged,
+        )
+        .width(Length::Fixed(80.0)),
+    );
+    if panel.config.boss_hide_key.is_some() {
+        boss_hide = boss_hide.push(button(text("Clear")).on_press(Message::ClearBossHide));
+    }
+
+    let boss_kill_label = match panel.config.boss_kill_key {
+        Some(vk) => code_to_label(vk),
+        None => "None".to_string(),
+    };
+    let boss_kill_mod_selected = MODIFIER_CHOICES
+        .iter()
+        .copied()
+        .find(|m| m.code == panel.config.boss_kill_modifier);
+    let mut boss_kill = bind_row(
+        panel,
+        "Boss key (kill all):",
+        CaptureTarget::BossKill,
+        boss_kill_label,
+    );
+    boss_kill = boss_kill.push(
+        pick_list(
+            MODIFIER_CHOICES,
+            boss_kill_mod_selected,
+            Message::BossKillModifierChanged,
+        )
+        .width(Length::Fixed(80.0)),
+    );
+    if panel.config.boss_kill_key.is_some() {
+        boss_kill = boss_kill.push(button(text("Clear")).on_press(Message::ClearBossKill));
+    }
+
     column![
         section_header("Keyboard Hotkeys"),
         checkbox(panel.config.enable_keyboard_buttons)
@@ -428,6 +481,12 @@ fn hotkeys_section(panel: &Panel) -> Element<'_, Message> {
         caption(
             "Toggle previews shows/hides all preview windows with one key — independent of \
              keyboard cycling. Leave unbound if you don't want it."
+        ),
+        boss_hide,
+        boss_kill,
+        caption(
+            "Boss keys: hide+mute minimizes and mutes every EVE client and hides the overlay \
+             (press again to restore); kill all force-quits every EVE client and Nicotine itself."
         ),
         checkbox(panel.config.enable_mouse_buttons)
             .label("Cycle on mouse side buttons (XBUTTON1/XBUTTON2)")

--- a/src/keyboard_listener.rs
+++ b/src/keyboard_listener.rs
@@ -26,6 +26,10 @@ pub struct KeyboardConfig {
     pub character_hotkeys: HashMap<String, CharacterHotkey>,
     pub toggle_previews_key: Option<u16>,
     pub toggle_previews_modifier: Option<u16>,
+    pub boss_hide_key: Option<u16>,
+    pub boss_hide_modifier: Option<u16>,
+    pub boss_kill_key: Option<u16>,
+    pub boss_kill_modifier: Option<u16>,
 }
 
 impl KeyboardConfig {
@@ -40,6 +44,10 @@ impl KeyboardConfig {
             character_hotkeys: c.character_hotkeys.clone(),
             toggle_previews_key: c.toggle_previews_key,
             toggle_previews_modifier: c.toggle_previews_modifier,
+            boss_hide_key: c.boss_hide_key,
+            boss_hide_modifier: c.boss_hide_modifier,
+            boss_kill_key: c.boss_kill_key,
+            boss_kill_modifier: c.boss_kill_modifier,
         }
     }
 
@@ -48,7 +56,11 @@ impl KeyboardConfig {
     /// off AND no character hotkeys AND no preview-toggle key are bound —
     /// otherwise a press it cares about would be missed.
     fn has_work(&self) -> bool {
-        self.enable || !self.character_hotkeys.is_empty() || self.toggle_previews_key.is_some()
+        self.enable
+            || !self.character_hotkeys.is_empty()
+            || self.toggle_previews_key.is_some()
+            || self.boss_hide_key.is_some()
+            || self.boss_kill_key.is_some()
     }
 }
 
@@ -80,6 +92,11 @@ impl KeyboardListener {
         let mut pressed_modifiers: HashSet<u16> = HashSet::new();
         let mut announced_listening = false;
         let mut announced_idle = false;
+        // Boss-key (hide+mute) state, so a second press restores exactly
+        // what the first press minimized + muted.
+        let mut bossed = false;
+        let mut boss_minimized: Vec<u32> = Vec::new();
+        let mut boss_muted: Vec<u32> = Vec::new();
 
         loop {
             let snap = shared.lock().unwrap().clone();
@@ -150,6 +167,8 @@ impl KeyboardListener {
             let modifier_codes: HashSet<u16> = std::iter::empty()
                 .chain(snap.modifier_key)
                 .chain(snap.toggle_previews_modifier)
+                .chain(snap.boss_hide_modifier)
+                .chain(snap.boss_kill_modifier)
                 .chain(snap.character_hotkeys.values().filter_map(|hk| hk.modifier))
                 .collect();
             // Forget pressed modifiers that are no longer modifiers in
@@ -233,6 +252,63 @@ impl KeyboardListener {
                             "Preview windows toggled {} via hotkey",
                             if live.show_previews { "on" } else { "off" }
                         );
+                    }
+                    continue;
+                }
+
+                // Boss key — hide + mute (a toggle). On press, minimize and
+                // mute every EVE client and hide the overlay; on the next
+                // press, restore exactly what we changed. Global — not
+                // gated on focus (it's an emergency key). Acts on the
+                // initial press only so a held key doesn't strobe.
+                if toggle_previews_should_fire(
+                    snap.boss_hide_key,
+                    snap.boss_hide_modifier,
+                    code,
+                    &pressed_modifiers,
+                ) {
+                    if event.value() == 1 {
+                        if bossed {
+                            // Restore.
+                            for id in boss_minimized.drain(..) {
+                                let _ = wm.restore_window(id);
+                            }
+                            crate::boss::unmute(&boss_muted);
+                            boss_muted.clear();
+                            live.lock().unwrap().bossed = false;
+                            bossed = false;
+                            println!("Boss key: restored");
+                        } else {
+                            // Engage: minimize every EVE window, mute their
+                            // audio, hide the overlay.
+                            boss_minimized.clear();
+                            if let Ok(windows) = wm.get_eve_windows() {
+                                for w in windows {
+                                    if wm.minimize_window(w.id).is_ok() {
+                                        boss_minimized.push(w.id);
+                                    }
+                                }
+                            }
+                            boss_muted = crate::boss::mute_eve(&crate::boss::eve_client_pids());
+                            live.lock().unwrap().bossed = true;
+                            bossed = true;
+                            println!("Boss key: hidden + muted {} client(s)", boss_minimized.len());
+                        }
+                    }
+                    continue;
+                }
+
+                // Boss key — kill all. Force-terminate every EVE client and
+                // every Nicotine process (this one included). No undo.
+                if toggle_previews_should_fire(
+                    snap.boss_kill_key,
+                    snap.boss_kill_modifier,
+                    code,
+                    &pressed_modifiers,
+                ) {
+                    if event.value() == 1 {
+                        eprintln!("Boss key: killing all EVE + Nicotine processes");
+                        crate::boss::kill_all();
                     }
                     continue;
                 }
@@ -567,6 +643,10 @@ mod tests {
             character_hotkeys: HashMap::new(),
             toggle_previews_key: None,
             toggle_previews_modifier: None,
+            boss_hide_key: None,
+            boss_hide_modifier: None,
+            boss_kill_key: None,
+            boss_kill_modifier: None,
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@
 #![cfg_attr(all(windows, not(debug_assertions)), windows_subsystem = "windows")]
 
 mod audio;
+mod boss;
 mod config;
 mod config_panel;
 mod cycle_state;

--- a/src/preview_windows/mod.rs
+++ b/src/preview_windows/mod.rs
@@ -554,9 +554,14 @@ impl PreviewManager {
     /// re-running this hides the newly-active preview and reshows the one
     /// cycled away from.
     fn apply_active_visibility(&mut self) {
-        let hide_active = self.live.lock().unwrap().hide_active_preview;
+        let (hide_active, bossed) = {
+            let live = self.live.lock().unwrap();
+            (live.hide_active_preview, live.bossed)
+        };
+        // The boss key hides the whole overlay; otherwise fall back to the
+        // per-client "hide active" rule.
         for preview in self.previews.values_mut() {
-            let want_hidden = preview_should_hide(hide_active, preview.is_active);
+            let want_hidden = bossed || preview_should_hide(hide_active, preview.is_active);
             if want_hidden == preview.hidden {
                 continue;
             }
@@ -570,6 +575,13 @@ impl PreviewManager {
             };
             unsafe {
                 let _ = ShowWindow(preview.hwnd, cmd);
+            }
+        }
+        // Boss key hides the list-view window too.
+        if let Some(list) = &self.list {
+            let cmd = if bossed { SW_HIDE } else { SW_SHOWNOACTIVATE };
+            unsafe {
+                let _ = ShowWindow(list.hwnd, cmd);
             }
         }
     }

--- a/src/preview_x11/mod.rs
+++ b/src/preview_x11/mod.rs
@@ -541,9 +541,14 @@ impl PreviewManager {
     /// so re-running this hides the newly-active preview and remaps the
     /// one cycled away from.
     fn apply_active_visibility(&mut self) {
-        let hide_active = self.live.lock_recover().hide_active_preview;
+        let (hide_active, bossed) = {
+            let live = self.live.lock_recover();
+            (live.hide_active_preview, live.bossed)
+        };
+        // The boss key hides the whole overlay; otherwise fall back to the
+        // per-client "hide active" rule.
         for preview in self.previews.values_mut() {
-            let want_hidden = preview_should_hide(hide_active, preview.is_active);
+            let want_hidden = bossed || preview_should_hide(hide_active, preview.is_active);
             if want_hidden == preview.hidden {
                 continue;
             }
@@ -555,6 +560,15 @@ impl PreviewManager {
                 // Backing contents are undefined after a remap; force the
                 // loop-tick repaint to re-present a complete frame.
                 preview.dirty = true;
+            }
+        }
+        // Boss key hides the list-view window too. map/unmap on an
+        // already-in-state window is a no-op, so this is safe each tick.
+        if let Some(list) = &self.list_window {
+            if bossed {
+                let _ = self.conn.unmap_window(list.window);
+            } else {
+                let _ = self.conn.map_window(list.window);
             }
         }
     }

--- a/src/windows_input.rs
+++ b/src/windows_input.rs
@@ -26,6 +26,8 @@ const HOTKEY_BACKWARD_ID: i32 = 1002;
 /// Global hotkey that flips `LiveSettings.show_previews` (show/hide all
 /// preview windows). Registered only when the user has bound a key.
 const HOTKEY_TOGGLE_PREVIEWS_ID: i32 = 1003;
+const HOTKEY_BOSS_HIDE_ID: i32 = 1004;
+const HOTKEY_BOSS_KILL_ID: i32 = 1005;
 /// Per-character hotkey IDs are assigned starting here, one per bound
 /// character, in the order the config lists them. Separated from the
 /// cycle IDs so the message dispatch can tell them apart by ID range.
@@ -239,6 +241,12 @@ fn run_listener(
     // Register keyboard hotkeys if enabled.
     register_hotkeys(&config);
 
+    // Boss-key (hide+mute) state, so a second press restores exactly what
+    // the first press minimized + muted.
+    let mut bossed = false;
+    let mut boss_minimized: Vec<u32> = Vec::new();
+    let mut boss_muted: Vec<u32> = Vec::new();
+
     let mut msg = MSG::default();
     loop {
         let got = unsafe { GetMessageW(&mut msg, None, 0, 0) };
@@ -316,6 +324,42 @@ fn run_listener(
             continue;
         }
 
+        // Boss key — hide + mute (a toggle). Minimize + mute every EVE
+        // client and hide the overlay; press again to restore exactly what
+        // we changed.
+        if msg.message == WM_HOTKEY && msg.wParam.0 as i32 == HOTKEY_BOSS_HIDE_ID {
+            if bossed {
+                for id in boss_minimized.drain(..) {
+                    let _ = wm.restore_window(id);
+                }
+                crate::boss::unmute(&boss_muted);
+                boss_muted.clear();
+                live.lock().unwrap().bossed = false;
+                bossed = false;
+                println!("Boss key: restored");
+            } else {
+                boss_minimized.clear();
+                if let Ok(windows) = wm.get_eve_windows() {
+                    for w in windows {
+                        if wm.minimize_window(w.id).is_ok() {
+                            boss_minimized.push(w.id);
+                        }
+                    }
+                }
+                boss_muted = crate::boss::mute_eve(&crate::boss::eve_client_pids());
+                live.lock().unwrap().bossed = true;
+                bossed = true;
+                println!("Boss key: hidden + muted {} client(s)", boss_minimized.len());
+            }
+            continue;
+        }
+
+        // Boss key — kill all. No undo.
+        if msg.message == WM_HOTKEY && msg.wParam.0 as i32 == HOTKEY_BOSS_KILL_ID {
+            eprintln!("Boss key: killing all EVE + Nicotine processes");
+            crate::boss::kill_all();
+        }
+
         // Per-character jump hotkey?
         if msg.message == WM_HOTKEY {
             let id = msg.wParam.0 as i32;
@@ -378,6 +422,26 @@ unsafe fn do_register_hotkeys(config: &Config) {
         );
     }
 
+    // Boss keys — global, independent of cycling enable.
+    if let Some(vk) = config.boss_hide_key {
+        let modifier = config.boss_hide_modifier.and_then(modifier_kind);
+        let _ = RegisterHotKey(
+            None,
+            HOTKEY_BOSS_HIDE_ID,
+            modifier_to_winapi(modifier),
+            vk as u32,
+        );
+    }
+    if let Some(vk) = config.boss_kill_key {
+        let modifier = config.boss_kill_modifier.and_then(modifier_kind);
+        let _ = RegisterHotKey(
+            None,
+            HOTKEY_BOSS_KILL_ID,
+            modifier_to_winapi(modifier),
+            vk as u32,
+        );
+    }
+
     let mut lookup = character_lookup().lock().unwrap();
     lookup.clear();
     for plan in plan_character_hotkeys(
@@ -406,6 +470,8 @@ fn unregister_hotkeys() {
         let _ = UnregisterHotKey(None, HOTKEY_FORWARD_ID);
         let _ = UnregisterHotKey(None, HOTKEY_BACKWARD_ID);
         let _ = UnregisterHotKey(None, HOTKEY_TOGGLE_PREVIEWS_ID);
+        let _ = UnregisterHotKey(None, HOTKEY_BOSS_HIDE_ID);
+        let _ = UnregisterHotKey(None, HOTKEY_BOSS_KILL_ID);
         let mut lookup = character_lookup().lock().unwrap();
         for id in lookup.keys() {
             let _ = UnregisterHotKey(None, *id);


### PR DESCRIPTION
- Two separately-bindable emergency hotkeys (default unbound):
  - **Hide + mute** (a toggle): minimizes and mutes every EVE client and hides the overlay; press again to restore exactly what was minimized + muted. Global (not focus-gated).
  - **Kill all:** force-terminates every EVE client and every Nicotine process (this one included). No confirmation.
- New `boss` module: EVE/Nicotine PID enumeration, kill-all (Linux `SIGKILL` via `/proc`, Windows `TerminateProcess` via toolhelp), and per-app audio muting (Linux via `pactl`; Windows is a documented no-op pending Core Audio).
- Config fields + transient `bossed` live flag; config-panel bind rows with modifiers + clear.
- Linux (`keyboard_listener`) and Windows (`windows_input`) both register and act on the boss hotkeys; X11 and Windows preview managers hide the overlay while bossed.
