### PR TITLE
Unified keybind input — chords, mouse buttons, and wheel at every bind site

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,10 +153,19 @@ sudo evtest  # Select your mouse, then click buttons to see their codes
 Edit `~/.config/nicotine/config.toml` to customize:
 ```toml
 enable_keyboard_buttons = true
-forward_key = 15  # TAB Key
-backward_key = 15  # TAB Key - modifier_key applied if set in config
-keyboard_device_path = None # Device path /dev/input/eventX (OPTIONAL but you may need to set this if keybinds don't work)
-modifier_key = None # You will have to add this if you want a modifier key for backward cycling
+keyboard_device_path = None # /dev/input/eventX (OPTIONAL; set if keybinds don't work)
+
+# Each cycle/toggle binding is a Hotkey: a modifier chord plus a trigger
+# (key, mouse button, or wheel notch). The config panel writes these for you.
+[forward_key]
+mods = []      # held-modifier codes, e.g. [42] = Shift
+kind = "Key"   # "Key" | "Mouse" | "Wheel"
+code = 15      # KEY_TAB
+
+[backward_key]
+mods = [42]    # Shift
+kind = "Key"
+code = 15      # i.e. Shift+Tab
 ```
 
 **Common button codes:**
@@ -178,7 +187,9 @@ sudo evtest /dev/input/eventX # Replace X with the correct event number i.e even
 
 ### Config Panel & Previews
 
-`nicotine start` opens the config panel and spawns one preview window per running EVE client. The panel has four sections: **Display Mode** (Previews vs List), **Cycle Order** (character list + per-character jump hotkeys), **Keyboard Hotkeys**, and **Preview Windows** (size sliders, show/hide toggle). Changes apply live; saves debounce to disk.
+`nicotine start` opens the config panel and spawns one preview window per running EVE client. The panel has four sections: **Display Mode** (Previews vs List), **Cycle Order** (character list with a keybind chip per character), **Keyboard Hotkeys** (forward / backward / toggle-overlay), and **Preview Windows** (size sliders, show/hide toggle). Changes apply live; saves debounce to disk.
+
+Every binding uses the same keybind chip: **left-click** to record the next input — a key chord (e.g. Ctrl+Shift+J), a mouse button, or a wheel notch — and **right-click** to clear. The mouse wheel can cycle clients (forward/backward), and mouse/wheel bindings can carry modifiers too.
 
 Previews and the list window:
 - **Left-click-drag** to reposition; edges snap to adjacent windows
@@ -208,7 +219,7 @@ backward_button = 275      # Button 8
 minimize_inactive = false  # Minimize clients when cycling away (saves resources)
 ```
 
-Per-character jump hotkeys live under `[character_hotkeys."Name"]` with `vk` and optional `modifier`; the config panel writes them for you.
+Per-character jump hotkeys live under `[character_hotkeys."Name"]` as a Hotkey (`mods`, `kind`, `code`); forward/backward/toggle bindings use the same shape. All support key chords, mouse buttons, or the wheel. The config panel writes them for you.
 
 ## Architecture
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -51,7 +51,6 @@ pub struct Hotkey {
     pub code: u16,
 }
 
-#[cfg_attr(not(test), allow(dead_code))] // wired into the bind sites in following commits
 impl Hotkey {
     /// A bare keyboard-key binding (no modifiers).
     pub fn key(code: u16) -> Self {
@@ -80,6 +79,12 @@ impl Hotkey {
     /// and vice-versa).
     pub fn mods_match(&self, held: &std::collections::HashSet<u16>) -> bool {
         self.mods.len() == held.len() && self.mods.iter().all(|m| held.contains(m))
+    }
+
+    /// Whether anything is bound. Unbound = the default (a key trigger with
+    /// code 0).
+    pub fn is_bound(&self) -> bool {
+        !(self.kind == TriggerKind::Key && self.code == 0)
     }
 
     /// True if `code`/`kind` and modifiers all match the given event.
@@ -163,10 +168,13 @@ pub struct Config {
     pub backward_button: u16, // BTN_EXTRA (mouse button 8)
     #[serde(default = "default_enable_keyboard")]
     pub enable_keyboard_buttons: bool,
+    /// Forward-cycle binding (key chord, mouse button, or wheel).
     #[serde(default = "default_forward_key")]
-    pub forward_key: u16, // KEY_TAB (15) - Tab for forward, Shift+Tab for backward
+    pub forward_key: Hotkey,
+    /// Backward-cycle binding. Default is Shift+forward as a normal chord
+    /// (no separate "modifier key" field any more).
     #[serde(default = "default_backward_key")]
-    pub backward_key: u16, // KEY_TAB (15) - Track SHIFT modifier internally
+    pub backward_key: Hotkey,
     #[serde(default = "default_mouse_device_name")]
     pub mouse_device_name: Option<String>,
     #[serde(default = "default_mouse_device_path")]
@@ -175,8 +183,6 @@ pub struct Config {
     pub minimize_inactive: bool,
     #[serde(default = "default_keyboard_device_path")]
     pub keyboard_device_path: Option<String>,
-    #[serde(default = "default_modifier_key")]
-    pub modifier_key: Option<u16>,
     /// Width of preview windows in pixels (Windows only). Single global value
     /// — every preview gets the same size. Aspect ratio is preserved on the
     /// thumbnail; the window is sized exactly as configured.
@@ -204,17 +210,10 @@ pub struct Config {
     /// preview managers still just read `preview_width`/`preview_height`.
     #[serde(default = "default_constrain_aspect")]
     pub constrain_aspect: bool,
-    /// Optional global hotkey (platform key code — evdev on Linux, Win32
-    /// VK on Windows) that toggles preview-window visibility, i.e. flips
-    /// `show_previews`. `None` = unbound. Bound via the panel's Hotkeys
-    /// tab just like the cycle keys.
+    /// Binding that toggles overlay visibility. Default unbound
+    /// (`Hotkey::default()`, code 0). Bound via the panel like the cycle keys.
     #[serde(default)]
-    pub toggle_previews_key: Option<u16>,
-    /// Optional modifier (Shift/Ctrl/Alt, as a platform key code) that
-    /// must be held with `toggle_previews_key` for the toggle to fire.
-    /// `None` = no modifier (the bare key toggles).
-    #[serde(default)]
-    pub toggle_previews_modifier: Option<u16>,
+    pub toggle_previews_key: Hotkey,
     /// Ordered list of EVE character names. Forward/backward cycling
     /// traverses this order; `switch N` maps target N to entry N-1.
     /// Empty list = cycle through whatever order the window manager
@@ -290,23 +289,23 @@ fn default_enable_keyboard() -> bool {
 }
 
 #[cfg(unix)]
-fn default_forward_key() -> u16 {
-    15 // KEY_TAB — evdev code
+fn default_forward_key() -> Hotkey {
+    Hotkey::key(15) // Tab
 }
 
 #[cfg(windows)]
-fn default_forward_key() -> u16 {
-    0x7A // VK_F11
+fn default_forward_key() -> Hotkey {
+    Hotkey::key(0x7A) // F11
 }
 
 #[cfg(unix)]
-fn default_backward_key() -> u16 {
-    15 // KEY_TAB (Modifier applied if set) — evdev code
+fn default_backward_key() -> Hotkey {
+    Hotkey::key_with_mods(15, vec![42]) // Shift+Tab
 }
 
 #[cfg(windows)]
-fn default_backward_key() -> u16 {
-    0x79 // VK_F10
+fn default_backward_key() -> Hotkey {
+    Hotkey::key(0x79) // F10
 }
 
 fn default_mouse_device_name() -> Option<String> {
@@ -323,10 +322,6 @@ fn default_minimize_inactive() -> bool {
 
 fn default_keyboard_device_path() -> Option<String> {
     None
-}
-
-fn default_modifier_key() -> Option<u16> {
-    None // No modifier for backward shifting by default
 }
 
 fn default_preview_width() -> u32 {
@@ -460,15 +455,13 @@ impl Config {
             mouse_device_path: default_mouse_device_path(),
             minimize_inactive: default_minimize_inactive(),
             keyboard_device_path: default_keyboard_device_path(),
-            modifier_key: default_modifier_key(),
             preview_width: default_preview_width(),
             preview_height: default_preview_height(),
             preview_opacity: default_preview_opacity(),
             show_previews: default_show_previews(),
             hide_active_preview: default_hide_active_preview(),
             constrain_aspect: default_constrain_aspect(),
-            toggle_previews_key: None,
-            toggle_previews_modifier: None,
+            toggle_previews_key: Hotkey::default(),
             characters: Vec::new(),
             display_mode: default_display_mode(),
             positions_locked: false,
@@ -581,21 +574,19 @@ mod tests {
             forward_button: 276,
             backward_button: 275,
             enable_keyboard_buttons: false,
-            forward_key: 15,
-            backward_key: 15,
+            forward_key: Hotkey::key(15),
+            backward_key: Hotkey::key(15),
             mouse_device_name: None,
             mouse_device_path: None,
             minimize_inactive: false,
             keyboard_device_path: None,
-            modifier_key: None,
             preview_width: 320,
             preview_height: 180,
             preview_opacity: 100,
             show_previews: true,
             hide_active_preview: false,
             constrain_aspect: false,
-            toggle_previews_key: None,
-            toggle_previews_modifier: None,
+            toggle_previews_key: Hotkey::default(),
             characters: Vec::new(),
             display_mode: DisplayMode::Previews,
             positions_locked: false,
@@ -620,21 +611,19 @@ mod tests {
             forward_button: 276,
             backward_button: 275,
             enable_keyboard_buttons: false,
-            forward_key: 15,
-            backward_key: 15,
+            forward_key: Hotkey::key(15),
+            backward_key: Hotkey::key(15),
             mouse_device_name: None,
             mouse_device_path: None,
             minimize_inactive: false,
             keyboard_device_path: None,
-            modifier_key: None,
             preview_width: 320,
             preview_height: 180,
             preview_opacity: 100,
             show_previews: true,
             hide_active_preview: false,
             constrain_aspect: false,
-            toggle_previews_key: None,
-            toggle_previews_modifier: None,
+            toggle_previews_key: Hotkey::default(),
             characters: Vec::new(),
             display_mode: DisplayMode::Previews,
             positions_locked: false,
@@ -658,21 +647,19 @@ mod tests {
             forward_button: 276,
             backward_button: 275,
             enable_keyboard_buttons: false,
-            forward_key: 15,
-            backward_key: 15,
+            forward_key: Hotkey::key(15),
+            backward_key: Hotkey::key(15),
             mouse_device_name: None,
             mouse_device_path: None,
             minimize_inactive: false,
             keyboard_device_path: None,
-            modifier_key: None,
             preview_width: 320,
             preview_height: 180,
             preview_opacity: 55,
             show_previews: true,
             hide_active_preview: true,
             constrain_aspect: true,
-            toggle_previews_key: Some(67),
-            toggle_previews_modifier: Some(42),
+            toggle_previews_key: Hotkey::key_with_mods(67, vec![42]),
             characters: Vec::new(),
             display_mode: DisplayMode::Previews,
             positions_locked: false,
@@ -698,13 +685,8 @@ mod tests {
         );
         assert_eq!(
             deserialized.toggle_previews_key,
-            Some(67),
-            "toggle_previews_key binding must survive a save/load round-trip"
-        );
-        assert_eq!(
-            deserialized.toggle_previews_modifier,
-            Some(42),
-            "toggle_previews_modifier must survive a save/load round-trip"
+            Hotkey::key_with_mods(67, vec![42]),
+            "toggle_previews_key binding (chord) must survive a save/load round-trip"
         );
         assert_eq!(
             deserialized.window_width, 900,

--- a/src/config.rs
+++ b/src/config.rs
@@ -234,7 +234,7 @@ pub struct Config {
     /// cycle. Keyed by name so bindings follow reorders and renames
     /// without reassigning keys.
     #[serde(default)]
-    pub character_hotkeys: HashMap<String, CharacterHotkey>,
+    pub character_hotkeys: HashMap<String, Hotkey>,
     /// Config-panel window size in logical pixels. Persisted so a manual
     /// resize of the panel survives restarts; defaults to the original
     /// fixed window size.

--- a/src/config.rs
+++ b/src/config.rs
@@ -159,11 +159,11 @@ pub struct Config {
     #[serde(default = "default_enable_keyboard")]
     pub enable_keyboard_buttons: bool,
     /// Forward-cycle binding (key chord, mouse button, or wheel).
-    #[serde(default = "default_forward_key")]
+    #[serde(default = "default_forward_key", deserialize_with = "de_hotkey")]
     pub forward_key: Hotkey,
     /// Backward-cycle binding. Default is Shift+forward as a normal chord
     /// (no separate "modifier key" field any more).
-    #[serde(default = "default_backward_key")]
+    #[serde(default = "default_backward_key", deserialize_with = "de_hotkey")]
     pub backward_key: Hotkey,
     #[serde(default = "default_mouse_device_name")]
     pub mouse_device_name: Option<String>,
@@ -202,7 +202,7 @@ pub struct Config {
     pub constrain_aspect: bool,
     /// Binding that toggles overlay visibility. Default unbound
     /// (`Hotkey::default()`, code 0). Bound via the panel like the cycle keys.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "de_hotkey")]
     pub toggle_previews_key: Hotkey,
     /// Ordered list of EVE character names. Forward/backward cycling
     /// traverses this order; `switch N` maps target N to entry N-1.
@@ -276,6 +276,25 @@ fn default_enable_keyboard() -> bool {
 #[cfg(windows)]
 fn default_enable_keyboard() -> bool {
     true // F10/F11 are uncommon enough to enable by default for cycling
+}
+
+/// Deserialize a [`Hotkey`] from either the current table form or a legacy
+/// bare integer key code. Pre-unification configs stored `forward_key = 15`;
+/// this keeps those loading instead of erroring out on upgrade.
+fn de_hotkey<'de, D>(d: D) -> Result<Hotkey, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum Compat {
+        Legacy(u16),
+        Full(Hotkey),
+    }
+    Ok(match Compat::deserialize(d)? {
+        Compat::Legacy(code) => Hotkey::key(code),
+        Compat::Full(hk) => hk,
+    })
 }
 
 #[cfg(unix)]
@@ -508,6 +527,21 @@ impl Config {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn legacy_integer_hotkey_deserializes_and_table_form_too() {
+        #[derive(Deserialize)]
+        struct W {
+            #[serde(deserialize_with = "de_hotkey")]
+            k: Hotkey,
+        }
+        // Legacy bare integer.
+        let w: W = toml::from_str("k = 15").unwrap();
+        assert_eq!(w.k, Hotkey::key(15));
+        // Current table form with a chord.
+        let w2: W = toml::from_str("[k]\nmods = [42]\nkind = \"Key\"\ncode = 15").unwrap();
+        assert_eq!(w2.k, Hotkey::key_with_mods(15, vec![42]));
+    }
     use std::collections::HashSet;
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,6 +15,84 @@ pub struct CharacterHotkey {
     pub modifier: Option<u16>,
 }
 
+/// What kind of input triggers a [`Hotkey`]: a keyboard key, a mouse
+/// button, or a scroll-wheel notch. The `code` is interpreted per-kind —
+/// an evdev key/button code on Linux, a Win32 VK / XBUTTON on Windows; for
+/// `Wheel` it's [`WHEEL_UP`] / [`WHEEL_DOWN`].
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Default)]
+pub enum TriggerKind {
+    #[default]
+    Key,
+    Mouse,
+    Wheel,
+}
+
+/// Wheel-direction sentinels, used as [`Hotkey::code`] when the kind is
+/// `Wheel`. Small constants that never collide with real key/button codes.
+pub const WHEEL_UP: u16 = 1;
+pub const WHEEL_DOWN: u16 = 2;
+
+/// A unified input binding: a trigger (key, mouse button, or wheel notch)
+/// plus the set of modifier keys that must be held. Replaces the old
+/// single-key + optional-single-modifier shape so chords (Ctrl+Shift+J) and
+/// mouse / wheel bindings are all expressible, and the same widget can drive
+/// every bind site.
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Default)]
+pub struct Hotkey {
+    /// Modifier codes (Ctrl/Shift/Alt as platform codes) that must be held.
+    /// Empty = bare trigger. Compared as a set at match time; kept sorted
+    /// for stable serialization.
+    #[serde(default)]
+    pub mods: Vec<u16>,
+    /// Whether `code` names a key, a mouse button, or a wheel direction.
+    #[serde(default)]
+    pub kind: TriggerKind,
+    /// The trigger code, interpreted per `kind`.
+    pub code: u16,
+}
+
+#[cfg_attr(not(test), allow(dead_code))] // wired into the bind sites in following commits
+impl Hotkey {
+    /// A bare keyboard-key binding (no modifiers).
+    pub fn key(code: u16) -> Self {
+        Self {
+            mods: Vec::new(),
+            kind: TriggerKind::Key,
+            code,
+        }
+    }
+
+    /// A keyboard binding with held modifiers. The modifier list is sorted
+    /// and de-duplicated so equal chords compare equal regardless of the
+    /// order the user pressed them.
+    pub fn key_with_mods(code: u16, mut mods: Vec<u16>) -> Self {
+        mods.sort_unstable();
+        mods.dedup();
+        Self {
+            mods,
+            kind: TriggerKind::Key,
+            code,
+        }
+    }
+
+    /// True when the currently-held modifier set is exactly this binding's
+    /// modifiers — no more, no fewer (so Ctrl+J doesn't fire a bare-J bind,
+    /// and vice-versa).
+    pub fn mods_match(&self, held: &std::collections::HashSet<u16>) -> bool {
+        self.mods.len() == held.len() && self.mods.iter().all(|m| held.contains(m))
+    }
+
+    /// True if `code`/`kind` and modifiers all match the given event.
+    pub fn matches(
+        &self,
+        kind: TriggerKind,
+        code: u16,
+        held: &std::collections::HashSet<u16>,
+    ) -> bool {
+        self.kind == kind && self.code == code && self.mods_match(held)
+    }
+}
+
 /// How the visible-at-a-glance view of clients is rendered.
 #[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
 pub enum DisplayMode {
@@ -447,6 +525,47 @@ impl Config {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashSet;
+
+    #[test]
+    fn hotkey_mods_sorted_and_deduped() {
+        let hk = Hotkey::key_with_mods(30, vec![56, 29, 29, 42]);
+        assert_eq!(hk.mods, vec![29, 42, 56]); // sorted, deduped
+        assert_eq!(hk.kind, TriggerKind::Key);
+    }
+
+    #[test]
+    fn hotkey_mods_match_is_exact() {
+        let hk = Hotkey::key_with_mods(30, vec![29, 42]); // Ctrl+Shift+X
+        let exact: HashSet<u16> = [29, 42].into_iter().collect();
+        let subset: HashSet<u16> = [29].into_iter().collect();
+        let superset: HashSet<u16> = [29, 42, 56].into_iter().collect();
+        assert!(hk.mods_match(&exact));
+        assert!(!hk.mods_match(&subset), "missing a required modifier");
+        assert!(!hk.mods_match(&superset), "extra modifier held");
+    }
+
+    #[test]
+    fn bare_key_requires_no_modifiers() {
+        let hk = Hotkey::key(30);
+        let none: HashSet<u16> = HashSet::new();
+        let ctrl: HashSet<u16> = [29].into_iter().collect();
+        assert!(hk.matches(TriggerKind::Key, 30, &none));
+        assert!(!hk.matches(TriggerKind::Key, 30, &ctrl), "Ctrl held but bare bind");
+        assert!(!hk.matches(TriggerKind::Mouse, 30, &none), "wrong kind");
+    }
+
+    #[test]
+    fn hotkey_round_trips_through_toml() {
+        let hk = Hotkey {
+            mods: vec![29, 42],
+            kind: TriggerKind::Wheel,
+            code: WHEEL_UP,
+        };
+        let s = toml::to_string(&hk).unwrap();
+        let back: Hotkey = toml::from_str(&s).unwrap();
+        assert_eq!(hk, back);
+    }
 
     #[test]
     fn test_eve_height_adjusted_with_panel() {

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,16 +5,6 @@ use std::fs;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
-/// A single per-character hotkey binding. `vk` is a Win32 Virtual-Key
-/// code (or evdev code on Linux); `modifier` is an optional second VK
-/// that must be held down (typically Shift/Ctrl/Alt).
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
-pub struct CharacterHotkey {
-    pub vk: u16,
-    #[serde(default)]
-    pub modifier: Option<u16>,
-}
-
 /// What kind of input triggers a [`Hotkey`]: a keyboard key, a mouse
 /// button, or a scroll-wheel notch. The `code` is interpreted per-kind —
 /// an evdev key/button code on Linux, a Win32 VK / XBUTTON on Windows; for

--- a/src/config_panel/mod.rs
+++ b/src/config_panel/mod.rs
@@ -1,4 +1,4 @@
-use crate::config::{Config, Hotkey, LiveSettings};
+use crate::config::{Config, Hotkey, LiveSettings, TriggerKind, WHEEL_DOWN, WHEEL_UP};
 use iced::{Color, Element, Subscription, Task, Theme};
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
@@ -172,6 +172,34 @@ fn iced_mods_to_codes(m: &iced::keyboard::Modifiers) -> Vec<u16> {
     v
 }
 
+/// Map an iced mouse button to the code the runtime listener matches.
+/// Linux uses evdev BTN_* codes; Windows uses the XBUTTON numbering the
+/// low-level mouse hook reports (back=1, forward=2). Left/Right/Middle on
+/// Windows aren't delivered by that hook, so binding them there is inert.
+#[cfg(unix)]
+fn iced_button_to_code(b: iced::mouse::Button) -> Option<u16> {
+    use iced::mouse::Button;
+    Some(match b {
+        Button::Left => 0x110,    // BTN_LEFT (272)
+        Button::Right => 0x111,   // BTN_RIGHT (273)
+        Button::Middle => 0x112,  // BTN_MIDDLE (274)
+        Button::Back => 0x113,    // BTN_SIDE (275)
+        Button::Forward => 0x114, // BTN_EXTRA (276)
+        Button::Other(n) => n,
+    })
+}
+#[cfg(windows)]
+fn iced_button_to_code(b: iced::mouse::Button) -> Option<u16> {
+    use iced::mouse::Button;
+    match b {
+        Button::Back => Some(1),     // XBUTTON1
+        Button::Forward => Some(2),  // XBUTTON2
+        Button::Other(n) => Some(n),
+        // Not reported by the WM_XBUTTON low-level hook; not bindable.
+        Button::Left | Button::Right | Button::Middle => None,
+    }
+}
+
 /// Aspect ratio (width / height) used to lock the two preview dimensions
 /// together when "Constrain aspect ratio" is on. Guards a zero/empty
 /// dimension (only reachable via a hand-edited config) by falling back to
@@ -272,6 +300,9 @@ pub(super) struct Panel {
     pub new_character_buffer: String,
     /// When `Some(..)`, the next keypress binds to this field.
     pub capturing: Option<CaptureTarget>,
+    /// Modifiers held during an in-progress capture, so a mouse/wheel
+    /// trigger captured next can include the chord.
+    pub capture_mods: iced::keyboard::Modifiers,
     /// Timestamp of the last edit; the debounce subscription flushes to
     /// disk once this is older than `AUTOSAVE_DEBOUNCE`.
     pub last_change: Option<Instant>,
@@ -340,6 +371,7 @@ impl Panel {
             restack_supported,
             new_character_buffer: String::new(),
             capturing: None,
+            capture_mods: iced::keyboard::Modifiers::empty(),
             last_change: None,
             active_tab: Tab::Display,
             dragging: None,
@@ -354,6 +386,27 @@ impl Panel {
         self.last_change = Some(Instant::now());
     }
 
+    /// Commit a mouse-button / wheel trigger (with any held modifiers) to
+    /// the bind site currently capturing. Other (single-key) sites ignore
+    /// mouse/wheel until they're migrated to the unified Hotkey.
+    fn bind_captured_trigger(&mut self, kind: TriggerKind, code: u16) {
+        let Some(target) = self.capturing.clone() else {
+            return;
+        };
+        let mut mods = iced_mods_to_codes(&self.capture_mods);
+        mods.sort_unstable();
+        mods.dedup();
+        let hk = Hotkey { mods, kind, code };
+        if let CaptureTarget::Character(name) = &target {
+            self.config.character_hotkeys.insert(name.clone(), hk);
+            self.capturing = None;
+            self.capture_mods = iced::keyboard::Modifiers::empty();
+            self.touch();
+            #[cfg(windows)]
+            self.end_windows_capture();
+        }
+    }
+
     fn handle_capture_key(&mut self, event: iced::keyboard::Event) -> Task<Message> {
         use iced::keyboard::key::Named;
         use iced::keyboard::{Event, Key};
@@ -362,9 +415,17 @@ impl Panel {
             return Task::none();
         };
 
+        // Track held modifiers so a mouse/wheel trigger captured next can
+        // include the chord (ModifiersChanged carries no key to bind).
+        if let Event::ModifiersChanged(m) = event {
+            self.capture_mods = m;
+            return Task::none();
+        }
+
         let Event::KeyPressed { key, modifiers, .. } = event else {
             return Task::none();
         };
+        self.capture_mods = modifiers;
 
         // Escape cancels capture without binding.
         if matches!(key, Key::Named(Named::Escape)) {
@@ -453,6 +514,8 @@ pub(super) enum Message {
     UnhoverRow(usize),
     DropRow,
     KeyEvent(iced::keyboard::Event),
+    CaptureMouse(u16),
+    CaptureWheel(bool),
     ShowPreviewsToggled(bool),
     HideActivePreviewToggled(bool),
     ConstrainAspectToggled(bool),
@@ -593,6 +656,12 @@ fn update(panel: &mut Panel, message: Message) -> Task<Message> {
             }
             panel.dragging = None;
             panel.drag_hover = None;
+        }
+        Message::CaptureMouse(code) => {
+            panel.bind_captured_trigger(TriggerKind::Mouse, code);
+        }
+        Message::CaptureWheel(up) => {
+            panel.bind_captured_trigger(TriggerKind::Wheel, if up { WHEEL_UP } else { WHEEL_DOWN });
         }
         Message::KeyEvent(event) => {
             return panel.handle_capture_key(event);
@@ -781,7 +850,26 @@ fn subscription(panel: &Panel) -> Subscription<Message> {
     let mut subs = Vec::new();
     // Only listen for raw key events while a bind button is armed.
     if panel.capturing.is_some() {
-        subs.push(iced::keyboard::listen().map(Message::KeyEvent));
+        subs.push(iced::event::listen_with(|event, _status, _window| match event {
+            iced::Event::Keyboard(k) => Some(Message::KeyEvent(k)),
+            iced::Event::Mouse(iced::mouse::Event::ButtonPressed(b)) => {
+                iced_button_to_code(b).map(Message::CaptureMouse)
+            }
+            iced::Event::Mouse(iced::mouse::Event::WheelScrolled { delta }) => {
+                let y = match delta {
+                    iced::mouse::ScrollDelta::Lines { y, .. } => y,
+                    iced::mouse::ScrollDelta::Pixels { y, .. } => y,
+                };
+                if y > 0.0 {
+                    Some(Message::CaptureWheel(true))
+                } else if y < 0.0 {
+                    Some(Message::CaptureWheel(false))
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        }));
     }
     // Poll only while a save is pending so the debounce fires even with
     // no further input; stops once flushed.

--- a/src/config_panel/mod.rs
+++ b/src/config_panel/mod.rs
@@ -58,7 +58,6 @@ pub(super) const LOGO_SIZE: f32 = 44.0;
 pub(super) enum CaptureTarget {
     ForwardKey,
     BackwardKey,
-    ModifierKey,
     TogglePreviews,
     Character(String),
 }
@@ -236,60 +235,6 @@ fn constrain_dimensions(target_width: u32, ratio: f64) -> (u32, u32) {
     }
 }
 
-/// One entry in the modifier dropdown. Codes are platform-specific:
-/// Win32 VK on Windows, Linux evdev keycodes on Linux.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(super) struct ModifierChoice {
-    pub code: Option<u16>,
-    pub label: &'static str,
-}
-
-impl std::fmt::Display for ModifierChoice {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(self.label)
-    }
-}
-
-#[cfg(windows)]
-pub(super) const MODIFIER_CHOICES: &[ModifierChoice] = &[
-    ModifierChoice {
-        code: None,
-        label: "None",
-    },
-    ModifierChoice {
-        code: Some(0x10),
-        label: "Shift",
-    },
-    ModifierChoice {
-        code: Some(0x11),
-        label: "Ctrl",
-    },
-    ModifierChoice {
-        code: Some(0x12),
-        label: "Alt",
-    },
-];
-
-#[cfg(unix)]
-pub(super) const MODIFIER_CHOICES: &[ModifierChoice] = &[
-    ModifierChoice {
-        code: None,
-        label: "None",
-    },
-    ModifierChoice {
-        code: Some(42),
-        label: "Shift",
-    }, // KEY_LEFTSHIFT
-    ModifierChoice {
-        code: Some(29),
-        label: "Ctrl",
-    }, // KEY_LEFTCTRL
-    ModifierChoice {
-        code: Some(56),
-        label: "Alt",
-    }, // KEY_LEFTALT
-];
-
 pub(super) struct Panel {
     pub config: Config,
     /// Shared settings watched by the preview manager for live updates.
@@ -397,14 +342,19 @@ impl Panel {
         mods.sort_unstable();
         mods.dedup();
         let hk = Hotkey { mods, kind, code };
-        if let CaptureTarget::Character(name) = &target {
-            self.config.character_hotkeys.insert(name.clone(), hk);
-            self.capturing = None;
-            self.capture_mods = iced::keyboard::Modifiers::empty();
-            self.touch();
-            #[cfg(windows)]
-            self.end_windows_capture();
+        match &target {
+            CaptureTarget::ForwardKey => self.config.forward_key = hk,
+            CaptureTarget::BackwardKey => self.config.backward_key = hk,
+            CaptureTarget::TogglePreviews => self.config.toggle_previews_key = hk,
+            CaptureTarget::Character(name) => {
+                self.config.character_hotkeys.insert(name.clone(), hk);
+            }
         }
+        self.capturing = None;
+        self.capture_mods = iced::keyboard::Modifiers::empty();
+        self.touch();
+        #[cfg(windows)]
+        self.end_windows_capture();
     }
 
     fn handle_capture_key(&mut self, event: iced::keyboard::Event) -> Task<Message> {
@@ -445,7 +395,7 @@ impl Panel {
             key,
             Key::Named(Named::Control | Named::Shift | Named::Alt | Named::Super)
         );
-        if is_mod_key && matches!(target, CaptureTarget::Character(_)) {
+        if is_mod_key {
             return Task::none();
         }
 
@@ -455,16 +405,13 @@ impl Panel {
         let code = iced_key_to_code(&key);
 
         if let Some(vk) = code {
+            let hk = Hotkey::key_with_mods(vk, iced_mods_to_codes(&modifiers));
             match &target {
-                CaptureTarget::ForwardKey => self.config.forward_key = vk,
-                CaptureTarget::BackwardKey => self.config.backward_key = vk,
-                CaptureTarget::ModifierKey => self.config.modifier_key = Some(vk),
-                CaptureTarget::TogglePreviews => self.config.toggle_previews_key = Some(vk),
+                CaptureTarget::ForwardKey => self.config.forward_key = hk,
+                CaptureTarget::BackwardKey => self.config.backward_key = hk,
+                CaptureTarget::TogglePreviews => self.config.toggle_previews_key = hk,
                 CaptureTarget::Character(name) => {
-                    let mods = iced_mods_to_codes(&modifiers);
-                    self.config
-                        .character_hotkeys
-                        .insert(name.clone(), Hotkey::key_with_mods(vk, mods));
+                    self.config.character_hotkeys.insert(name.clone(), hk);
                 }
             }
             self.capturing = None;
@@ -501,12 +448,9 @@ pub(super) enum Message {
     RemoveCharacter(usize),
     NewCharacterChanged(String),
     AddCharacter,
-    ClearCharacterHotkey(String),
     KeyboardEnabledToggled(bool),
     MouseEnabledToggled(bool),
-    ClearModifier,
-    ClearTogglePreviews,
-    TogglePreviewsModifierChanged(ModifierChoice),
+    ClearBinding(CaptureTarget),
     StartCapture(CaptureTarget),
     TabSelected(Tab),
     GrabRow(usize),
@@ -588,10 +532,6 @@ fn update(panel: &mut Panel, message: Message) -> Task<Message> {
                 panel.touch();
             }
         }
-        Message::ClearCharacterHotkey(name) => {
-            panel.config.character_hotkeys.remove(&name);
-            panel.touch();
-        }
         Message::KeyboardEnabledToggled(v) => {
             panel.config.enable_keyboard_buttons = v;
             panel.touch();
@@ -600,17 +540,17 @@ fn update(panel: &mut Panel, message: Message) -> Task<Message> {
             panel.config.enable_mouse_buttons = v;
             panel.touch();
         }
-        Message::ClearModifier => {
-            panel.config.modifier_key = None;
-            panel.touch();
-        }
-        Message::ClearTogglePreviews => {
-            panel.config.toggle_previews_key = None;
-            panel.config.toggle_previews_modifier = None;
-            panel.touch();
-        }
-        Message::TogglePreviewsModifierChanged(choice) => {
-            panel.config.toggle_previews_modifier = choice.code;
+        Message::ClearBinding(target) => {
+            match target {
+                CaptureTarget::ForwardKey => panel.config.forward_key = Hotkey::default(),
+                CaptureTarget::BackwardKey => panel.config.backward_key = Hotkey::default(),
+                CaptureTarget::TogglePreviews => {
+                    panel.config.toggle_previews_key = Hotkey::default()
+                }
+                CaptureTarget::Character(name) => {
+                    panel.config.character_hotkeys.remove(&name);
+                }
+            }
             panel.touch();
         }
         Message::StartCapture(target) => {

--- a/src/config_panel/mod.rs
+++ b/src/config_panel/mod.rs
@@ -1,4 +1,4 @@
-use crate::config::{CharacterHotkey, Config, LiveSettings};
+use crate::config::{Config, Hotkey, LiveSettings};
 use iced::{Color, Element, Subscription, Task, Theme};
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
@@ -129,6 +129,47 @@ impl SliderField {
 /// Keep only ASCII digits — constrains the editable slider readouts.
 fn digits_only(s: &str) -> String {
     s.chars().filter(|c| c.is_ascii_digit()).collect()
+}
+
+/// Render a unified Hotkey as a human label, e.g. "Ctrl+Shift+J",
+/// "Mouse4", "Wheel↑", or "unbound".
+pub(super) fn hotkey_label(hk: &Hotkey) -> String {
+    use crate::config::{TriggerKind, WHEEL_DOWN, WHEEL_UP};
+    if hk.kind == TriggerKind::Key && hk.code == 0 {
+        return "unbound".into();
+    }
+    let mut parts: Vec<String> = hk.mods.iter().map(|&m| code_to_label(m)).collect();
+    parts.push(match hk.kind {
+        TriggerKind::Key => code_to_label(hk.code),
+        TriggerKind::Mouse => format!("Mouse{}", hk.code),
+        TriggerKind::Wheel => match hk.code {
+            WHEEL_UP => "Wheel↑".into(),
+            WHEEL_DOWN => "Wheel↓".into(),
+            _ => "Wheel".into(),
+        },
+    });
+    parts.join("+")
+}
+
+/// Map iced's logical modifier flags to the platform modifier key codes
+/// the runtime listeners track (canonical left-variant codes).
+#[cfg(unix)]
+fn iced_mods_to_codes(m: &iced::keyboard::Modifiers) -> Vec<u16> {
+    let mut v = Vec::new();
+    if m.control() { v.push(29); }   // KEY_LEFTCTRL
+    if m.shift()   { v.push(42); }   // KEY_LEFTSHIFT
+    if m.alt()     { v.push(56); }   // KEY_LEFTALT
+    if m.logo()    { v.push(125); }  // KEY_LEFTMETA
+    v
+}
+#[cfg(windows)]
+fn iced_mods_to_codes(m: &iced::keyboard::Modifiers) -> Vec<u16> {
+    let mut v = Vec::new();
+    if m.control() { v.push(0x11); } // VK_CONTROL
+    if m.shift()   { v.push(0x10); } // VK_SHIFT
+    if m.alt()     { v.push(0x12); } // VK_MENU
+    if m.logo()    { v.push(0x5B); } // VK_LWIN
+    v
 }
 
 /// Aspect ratio (width / height) used to lock the two preview dimensions
@@ -321,7 +362,7 @@ impl Panel {
             return Task::none();
         };
 
-        let Event::KeyPressed { key, .. } = event else {
+        let Event::KeyPressed { key, modifiers, .. } = event else {
             return Task::none();
         };
 
@@ -336,6 +377,17 @@ impl Panel {
         // On Windows, OEM/punctuation VKs are layout-dependent; ask the OS
         // for the actually-held VK first so the captured code matches what
         // RegisterHotKey will see at runtime regardless of keyboard layout.
+        // A modifier key on its own isn't a trigger for a chord-capable
+        // binding: keep listening so the user can hold it and press the real
+        // key. (The dedicated single-modifier bind still records it.)
+        let is_mod_key = matches!(
+            key,
+            Key::Named(Named::Control | Named::Shift | Named::Alt | Named::Super)
+        );
+        if is_mod_key && matches!(target, CaptureTarget::Character(_)) {
+            return Task::none();
+        }
+
         #[cfg(windows)]
         let code = oem_vk_currently_pressed().or_else(|| iced_key_to_code(&key));
         #[cfg(unix)]
@@ -348,14 +400,10 @@ impl Panel {
                 CaptureTarget::ModifierKey => self.config.modifier_key = Some(vk),
                 CaptureTarget::TogglePreviews => self.config.toggle_previews_key = Some(vk),
                 CaptureTarget::Character(name) => {
-                    let modifier = self
-                        .config
-                        .character_hotkeys
-                        .get(name)
-                        .and_then(|h| h.modifier);
+                    let mods = iced_mods_to_codes(&modifiers);
                     self.config
                         .character_hotkeys
-                        .insert(name.clone(), CharacterHotkey { vk, modifier });
+                        .insert(name.clone(), Hotkey::key_with_mods(vk, mods));
                 }
             }
             self.capturing = None;
@@ -392,7 +440,6 @@ pub(super) enum Message {
     RemoveCharacter(usize),
     NewCharacterChanged(String),
     AddCharacter,
-    CharacterModifierChanged(String, ModifierChoice),
     ClearCharacterHotkey(String),
     KeyboardEnabledToggled(bool),
     MouseEnabledToggled(bool),
@@ -477,18 +524,6 @@ fn update(panel: &mut Panel, message: Message) -> Task<Message> {
                 panel.new_character_buffer.clear();
                 panel.touch();
             }
-        }
-        Message::CharacterModifierChanged(name, choice) => {
-            let entry = panel
-                .config
-                .character_hotkeys
-                .entry(name)
-                .or_insert(CharacterHotkey {
-                    vk: 0,
-                    modifier: None,
-                });
-            entry.modifier = choice.code;
-            panel.touch();
         }
         Message::ClearCharacterHotkey(name) => {
             panel.config.character_hotkeys.remove(&name);

--- a/src/config_panel/ui.rs
+++ b/src/config_panel/ui.rs
@@ -2,16 +2,16 @@
 //! the four body sections (display mode, cycle order, hotkeys, previews).
 
 use iced::widget::{
-    button, checkbox, column, container, mouse_area, pick_list, radio, row, slider, text,
-    text_input, tooltip, Space,
+    button, checkbox, column, container, mouse_area, radio, row, slider, text, text_input,
+    tooltip, Space,
 };
 use iced::{Alignment, Background, Border, Color, Element, Font, Length, Shadow, Vector};
 
-use crate::config::DisplayMode;
+use crate::config::{DisplayMode, Hotkey};
 
 use super::{
-    code_to_label, hotkey_label, CaptureTarget, Message, Panel, SliderField, Tab, CAPTION_SIZE, LOGO_SIZE,
-    MODIFIER_CHOICES, NICOTINE_BLACK, NICOTINE_CREAM, NICOTINE_GOLD, NICOTINE_GREEN, NICOTINE_RED,
+    hotkey_label, CaptureTarget, Message, Panel, SliderField, Tab, CAPTION_SIZE, LOGO_SIZE,
+    NICOTINE_BLACK, NICOTINE_CREAM, NICOTINE_GOLD, NICOTINE_GREEN, NICOTINE_RED,
     SECTION_SIZE,
 };
 
@@ -290,7 +290,7 @@ fn characters_section(panel: &Panel) -> Element<'_, Message> {
                 label,
                 130.0,
             ))
-            .on_right_press(Message::ClearCharacterHotkey(name.clone())),
+            .on_right_press(Message::ClearBinding(CaptureTarget::Character(name.clone()))),
             container(
                 text("Left-click: set  ·  Right-click: clear")
                     .size(CAPTION_SIZE)
@@ -344,75 +344,30 @@ fn characters_section(panel: &Panel) -> Element<'_, Message> {
 }
 
 fn hotkeys_section(panel: &Panel) -> Element<'_, Message> {
-    let forward = bind_row(
-        panel,
-        "Forward:",
-        CaptureTarget::ForwardKey,
-        code_to_label(panel.config.forward_key),
-    );
-    let backward = bind_row(
-        panel,
-        "Backward:",
-        CaptureTarget::BackwardKey,
-        code_to_label(panel.config.backward_key),
-    );
-
-    let modifier_label = match panel.config.modifier_key {
-        Some(vk) => code_to_label(vk),
-        None => "None".to_string(),
-    };
-    let mut modifier = bind_row(
-        panel,
-        "Modifier:",
-        CaptureTarget::ModifierKey,
-        modifier_label,
-    );
-    if panel.config.modifier_key.is_some() {
-        modifier = modifier.push(button(text("Clear")).on_press(Message::ClearModifier));
-    }
-
-    let toggle_label = match panel.config.toggle_previews_key {
-        Some(vk) => code_to_label(vk),
-        None => "None".to_string(),
-    };
-    let toggle_mod_selected = MODIFIER_CHOICES
-        .iter()
-        .copied()
-        .find(|m| m.code == panel.config.toggle_previews_modifier);
-    let mut toggle_previews = bind_row(
-        panel,
-        "Toggle previews:",
-        CaptureTarget::TogglePreviews,
-        toggle_label,
-    );
-    toggle_previews = toggle_previews.push(
-        pick_list(
-            MODIFIER_CHOICES,
-            toggle_mod_selected,
-            Message::TogglePreviewsModifierChanged,
-        )
-        .width(Length::Fixed(80.0)),
-    );
-    if panel.config.toggle_previews_key.is_some() {
-        toggle_previews =
-            toggle_previews.push(button(text("Clear")).on_press(Message::ClearTogglePreviews));
-    }
-
     column![
         section_header("Keyboard Hotkeys"),
         checkbox(panel.config.enable_keyboard_buttons)
             .label("Enable keyboard cycling")
             .on_toggle(Message::KeyboardEnabledToggled),
-        forward,
-        backward,
-        modifier,
-        caption(
-            "Click a binding to record the next key you press. Esc cancels. Set both keys to the \
-             same value with a modifier to cycle backward via modifier+key (e.g. Tab + Shift+Tab)."
+        keybind_chip_row(panel, "Forward:", CaptureTarget::ForwardKey, &panel.config.forward_key),
+        keybind_chip_row(
+            panel,
+            "Backward:",
+            CaptureTarget::BackwardKey,
+            &panel.config.backward_key,
         ),
-        toggle_previews,
         caption(
-            "Toggle previews shows/hides all preview windows with one key — independent of \
+            "Left-click a binding to record a key chord, mouse button, or wheel notch \
+             (Esc cancels). Right-click clears it. Backward defaults to Shift+forward."
+        ),
+        keybind_chip_row(
+            panel,
+            "Toggle overlay:",
+            CaptureTarget::TogglePreviews,
+            &panel.config.toggle_previews_key,
+        ),
+        caption(
+            "Toggle overlay shows/hides the whole overlay with one binding — independent of \
              keyboard cycling. Leave unbound if you don't want it."
         ),
         checkbox(panel.config.enable_mouse_buttons)
@@ -424,6 +379,40 @@ fn hotkeys_section(panel: &Panel) -> Element<'_, Message> {
         ),
     ]
     .spacing(8)
+    .into()
+}
+
+/// A labelled keybind chip: left-click to record (key chord / mouse button /
+/// wheel), right-click to clear, with a tooltip. Shared by every bind site.
+fn keybind_chip_row(
+    panel: &Panel,
+    label: &'static str,
+    target: CaptureTarget,
+    hk: &Hotkey,
+) -> Element<'static, Message> {
+    let text_label = if hk.is_bound() {
+        hotkey_label(hk)
+    } else {
+        "unbound".into()
+    };
+    let chip = tooltip(
+        mouse_area(bind_button(panel, target.clone(), text_label, 150.0))
+            .on_right_press(Message::ClearBinding(target)),
+        container(
+            text("Left-click: set  ·  Right-click: clear")
+                .size(CAPTION_SIZE)
+                .color(NICOTINE_BLACK),
+        )
+        .padding(6)
+        .style(|_| filled(NICOTINE_CREAM)),
+        tooltip::Position::Top,
+    );
+    row![
+        text(label).width(Length::Fixed(120.0)),
+        chip,
+    ]
+    .spacing(6)
+    .align_y(Alignment::Center)
     .into()
 }
 
@@ -506,22 +495,6 @@ fn slider_field<'a>(
     .spacing(8)
     .align_y(Alignment::Center)
     .into()
-}
-
-/// A labeled key-binding row (`<label>  [ bind chip ]`) for the
-/// Forward/Backward/Modifier entries on the Hotkeys tab.
-fn bind_row(
-    panel: &Panel,
-    label: &'static str,
-    target: CaptureTarget,
-    current: String,
-) -> iced::widget::Row<'static, Message> {
-    row![
-        text(label).width(Length::Fixed(120.0)),
-        bind_button(panel, target, current, 200.0),
-    ]
-    .spacing(6)
-    .align_y(Alignment::Center)
 }
 
 fn bind_button(

--- a/src/config_panel/ui.rs
+++ b/src/config_panel/ui.rs
@@ -3,14 +3,14 @@
 
 use iced::widget::{
     button, checkbox, column, container, mouse_area, pick_list, radio, row, slider, text,
-    text_input, Space,
+    text_input, tooltip, Space,
 };
 use iced::{Alignment, Background, Border, Color, Element, Font, Length, Shadow, Vector};
 
 use crate::config::DisplayMode;
 
 use super::{
-    code_to_label, CaptureTarget, Message, Panel, SliderField, Tab, CAPTION_SIZE, LOGO_SIZE,
+    code_to_label, hotkey_label, CaptureTarget, Message, Panel, SliderField, Tab, CAPTION_SIZE, LOGO_SIZE,
     MODIFIER_CHOICES, NICOTINE_BLACK, NICOTINE_CREAM, NICOTINE_GOLD, NICOTINE_GREEN, NICOTINE_RED,
     SECTION_SIZE,
 };
@@ -274,12 +274,40 @@ fn characters_section(panel: &Panel) -> Element<'_, Message> {
     .spacing(8);
 
     for (i, name) in panel.config.characters.iter().enumerate() {
-        let row1 = row![
+        // One compact keybind chip: left-click to record (a key chord, a
+        // mouse button, or a wheel notch), right-click to clear. The tooltip
+        // spells that out.
+        let label = panel
+            .config
+            .character_hotkeys
+            .get(name)
+            .map(hotkey_label)
+            .unwrap_or_else(|| "unbound".into());
+        let keybind = tooltip(
+            mouse_area(bind_button(
+                panel,
+                CaptureTarget::Character(name.clone()),
+                label,
+                130.0,
+            ))
+            .on_right_press(Message::ClearCharacterHotkey(name.clone())),
+            container(
+                text("Left-click: set  ·  Right-click: clear")
+                    .size(CAPTION_SIZE)
+                    .color(NICOTINE_BLACK),
+            )
+            .padding(6)
+            .style(|_| filled(NICOTINE_CREAM)),
+            tooltip::Position::Top,
+        );
+
+        let row = row![
             grip(i),
             text(format!("{}.", i + 1)),
             text_input("character name", name)
                 .on_input(move |s| Message::CharacterNameChanged(i, s))
                 .width(Length::Fill),
+            keybind,
             button(text("↑")).on_press(Message::MoveCharacterUp(i)),
             button(text("↓")).on_press(Message::MoveCharacterDown(i)),
             button(text("✕")).on_press(Message::RemoveCharacter(i)),
@@ -287,51 +315,9 @@ fn characters_section(panel: &Panel) -> Element<'_, Message> {
         .spacing(6)
         .align_y(Alignment::Center);
 
-        let current_mod = panel
-            .config
-            .character_hotkeys
-            .get(name)
-            .and_then(|h| h.modifier);
-        let selected = MODIFIER_CHOICES
-            .iter()
-            .copied()
-            .find(|m| m.code == current_mod);
-        let name_for_mod = name.clone();
-        let modifier_pick = pick_list(MODIFIER_CHOICES, selected, move |c| {
-            Message::CharacterModifierChanged(name_for_mod.clone(), c)
-        })
-        .width(Length::Fixed(80.0));
-
-        let binding_label = panel
-            .config
-            .character_hotkeys
-            .get(name)
-            .filter(|h| h.vk != 0)
-            .map(|h| code_to_label(h.vk))
-            .unwrap_or_else(|| "none".into());
-
-        let mut row2 = row![
-            Space::new().width(Length::Fixed(20.0)),
-            text("Hotkey:"),
-            modifier_pick,
-            bind_button(
-                panel,
-                CaptureTarget::Character(name.clone()),
-                binding_label,
-                110.0
-            ),
-        ]
-        .spacing(6)
-        .align_y(Alignment::Center);
-
-        if panel.config.character_hotkeys.contains_key(name) {
-            let n = name.clone();
-            row2 = row2.push(button(text("✕")).on_press(Message::ClearCharacterHotkey(n)));
-        }
-
         let is_dragged = panel.dragging == Some(i);
         let is_target = panel.dragging.is_some() && panel.drag_hover == Some(i) && !is_dragged;
-        let block = container(column![row1, row2].spacing(2))
+        let block = container(row)
             .padding(6)
             .style(move |_| drag_row_style(is_dragged, is_target));
         col = col.push(

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -284,6 +284,7 @@ impl Daemon {
             Arc::clone(&self.wm),
             Arc::clone(&self.state),
             Arc::clone(&held_modifiers),
+            Arc::clone(&self.live),
         );
         KeyboardListener::spawn(
             Arc::clone(&self.keyboard_config),

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -274,16 +274,23 @@ impl Daemon {
         // when `enable` is false. That way flipping `enable_*` on in
         // the panel after startup actually does something instead of
         // requiring a daemon restart.
+        // Currently-held modifier keys, written by the keyboard listener and
+        // read by the mouse listener so a mouse/wheel hotkey can require a
+        // modifier chord (Ctrl + Mouse4) even though the two listeners poll
+        // different evdev devices.
+        let held_modifiers = Arc::new(Mutex::new(std::collections::HashSet::<u16>::new()));
         MouseListener::spawn(
             Arc::clone(&self.mouse_config),
             Arc::clone(&self.wm),
             Arc::clone(&self.state),
+            Arc::clone(&held_modifiers),
         );
         KeyboardListener::spawn(
             Arc::clone(&self.keyboard_config),
             Arc::clone(&self.wm),
             Arc::clone(&self.state),
             Arc::clone(&self.live),
+            held_modifiers,
         );
         println!("Mouse + keyboard listeners spawned (live config hot-reload enabled)");
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -147,23 +147,19 @@ impl Daemon {
         #[cfg(windows)]
         type HotkeySig = (
             bool,
-            u16,
-            u16,
-            Option<u16>,
-            std::collections::HashMap<String, crate::config::CharacterHotkey>,
-            Option<u16>,
-            Option<u16>,
+            crate::config::Hotkey,
+            crate::config::Hotkey,
+            std::collections::HashMap<String, crate::config::Hotkey>,
+            crate::config::Hotkey,
         );
         #[cfg(windows)]
         fn hotkey_sig(c: &Config) -> HotkeySig {
             (
                 c.enable_keyboard_buttons,
-                c.forward_key,
-                c.backward_key,
-                c.modifier_key,
+                c.forward_key.clone(),
+                c.backward_key.clone(),
                 c.character_hotkeys.clone(),
-                c.toggle_previews_key,
-                c.toggle_previews_modifier,
+                c.toggle_previews_key.clone(),
             )
         }
         #[cfg(windows)]

--- a/src/keyboard_listener.rs
+++ b/src/keyboard_listener.rs
@@ -18,28 +18,24 @@ use std::time::Duration;
 #[derive(Clone, PartialEq, Eq)]
 pub struct KeyboardConfig {
     pub enable: bool,
-    pub forward_key: u16,
-    pub backward_key: u16,
-    pub modifier_key: Option<u16>,
+    pub forward_key: Hotkey,
+    pub backward_key: Hotkey,
     pub keyboard_device_path: Option<String>,
     pub minimize_inactive: bool,
     pub character_hotkeys: HashMap<String, Hotkey>,
-    pub toggle_previews_key: Option<u16>,
-    pub toggle_previews_modifier: Option<u16>,
+    pub toggle_previews_key: Hotkey,
 }
 
 impl KeyboardConfig {
     pub fn from_config(c: &Config) -> Self {
         Self {
             enable: c.enable_keyboard_buttons,
-            forward_key: c.forward_key,
-            backward_key: c.backward_key,
-            modifier_key: c.modifier_key,
+            forward_key: c.forward_key.clone(),
+            backward_key: c.backward_key.clone(),
             keyboard_device_path: c.keyboard_device_path.clone(),
             minimize_inactive: c.minimize_inactive,
             character_hotkeys: c.character_hotkeys.clone(),
-            toggle_previews_key: c.toggle_previews_key,
-            toggle_previews_modifier: c.toggle_previews_modifier,
+            toggle_previews_key: c.toggle_previews_key.clone(),
         }
     }
 
@@ -48,7 +44,7 @@ impl KeyboardConfig {
     /// off AND no character hotkeys AND no preview-toggle key are bound —
     /// otherwise a press it cares about would be missed.
     fn has_work(&self) -> bool {
-        self.enable || !self.character_hotkeys.is_empty() || self.toggle_previews_key.is_some()
+        self.enable || !self.character_hotkeys.is_empty() || self.toggle_previews_key.is_bound()
     }
 }
 
@@ -136,9 +132,7 @@ impl KeyboardListener {
 
             if !announced_listening {
                 println!(
-                    "Listening for keyboard keys: forward={} backward={} (+{} character hotkey(s))",
-                    snap.forward_key,
-                    snap.backward_key,
+                    "Listening for keyboard cycle/toggle/character hotkeys (+{} character hotkey(s))",
                     snap.character_hotkeys.len()
                 );
                 announced_listening = true;
@@ -150,8 +144,9 @@ impl KeyboardListener {
             // modifier). Recomputed each iteration so swapping
             // modifiers in the panel takes effect immediately.
             let modifier_codes: HashSet<u16> = std::iter::empty()
-                .chain(snap.modifier_key)
-                .chain(snap.toggle_previews_modifier)
+                .chain(snap.forward_key.mods.iter().copied())
+                .chain(snap.backward_key.mods.iter().copied())
+                .chain(snap.toggle_previews_key.mods.iter().copied())
                 .chain(snap.character_hotkeys.values().flat_map(|hk| hk.mods.iter().copied()))
                 .collect();
             // Forget pressed modifiers that are no longer modifiers in
@@ -224,12 +219,10 @@ impl KeyboardListener {
                 // and acts only on the initial press (value == 1) so a held
                 // key doesn't strobe show/hide on key-repeat. Consume the
                 // key either way so it can't also trigger cycling/switching.
-                if toggle_previews_should_fire(
-                    snap.toggle_previews_key,
-                    snap.toggle_previews_modifier,
-                    code,
-                    &pressed_modifiers,
-                ) {
+                if snap
+                    .toggle_previews_key
+                    .matches(TriggerKind::Key, code, &pressed_modifiers)
+                {
                     if event.value() == 1 {
                         let mut live = live.lock().unwrap();
                         live.show_previews = !live.show_previews;
@@ -247,25 +240,24 @@ impl KeyboardListener {
                 // disabled but kept the listener alive for character
                 // hotkeys — otherwise Tab would still cycle.
                 if snap.enable {
-                    let main_modifier_held = snap
-                        .modifier_key
-                        .map(|m| pressed_modifiers.contains(&m))
-                        .unwrap_or(false);
-                    if code == snap.backward_key && main_modifier_held {
+                    // Backward first: with exact-set modifier matching the
+                    // chords are disjoint, but a Shift+Tab backward should win
+                    // over a bare-Tab forward when they share a key.
+                    if snap
+                        .backward_key
+                        .matches(TriggerKind::Key, code, &pressed_modifiers)
+                    {
                         if let Err(e) = Self::cycle_backward(&wm, &state, snap.minimize_inactive) {
                             eprintln!("Failed to cycle backward: {}", e);
                         }
                         continue;
                     }
-                    if code == snap.forward_key {
+                    if snap
+                        .forward_key
+                        .matches(TriggerKind::Key, code, &pressed_modifiers)
+                    {
                         if let Err(e) = Self::cycle_forward(&wm, &state, snap.minimize_inactive) {
                             eprintln!("Failed to cycle forward: {}", e);
-                        }
-                        continue;
-                    }
-                    if code == snap.backward_key {
-                        if let Err(e) = Self::cycle_backward(&wm, &state, snap.minimize_inactive) {
-                            eprintln!("Failed to cycle backward: {}", e);
                         }
                         continue;
                     }
@@ -383,20 +375,6 @@ impl KeyboardListener {
         state.switch_to_character(name, &**wm, minimize_inactive)?;
         Ok(())
     }
-}
-
-/// Whether a key press should fire the preview-visibility toggle: the
-/// pressed `code` must match the bound key, and — if a modifier is bound —
-/// that modifier must currently be held. An unbound key (`None`) never
-/// fires; a binding with no modifier fires on the bare key regardless of
-/// which modifiers happen to be down (matching the no-modifier cycle keys).
-fn toggle_previews_should_fire(
-    toggle_key: Option<u16>,
-    toggle_modifier: Option<u16>,
-    code: u16,
-    pressed_modifiers: &HashSet<u16>,
-) -> bool {
-    toggle_key == Some(code) && toggle_modifier.is_none_or(|m| pressed_modifiers.contains(&m))
 }
 
 /// Pick the character (if any) whose hotkey matches a key press.
@@ -546,14 +524,12 @@ mod tests {
     fn idle_config() -> KeyboardConfig {
         KeyboardConfig {
             enable: false,
-            forward_key: 15,
-            backward_key: 15,
-            modifier_key: None,
+            forward_key: Hotkey::key(15),
+            backward_key: Hotkey::key(15),
             keyboard_device_path: None,
             minimize_inactive: false,
             character_hotkeys: HashMap::new(),
-            toggle_previews_key: None,
-            toggle_previews_modifier: None,
+            toggle_previews_key: Hotkey::default(),
         }
     }
 
@@ -568,7 +544,7 @@ mod tests {
         // off, no character hotkeys) must keep the listener attached, or
         // the toggle press would never be seen.
         let mut c = idle_config();
-        c.toggle_previews_key = Some(88);
+        c.toggle_previews_key = Hotkey::key(88);
         assert!(c.has_work());
     }
 
@@ -585,49 +561,4 @@ mod tests {
         assert!(with_char.has_work());
     }
 
-    #[test]
-    fn toggle_fires_on_bare_key_when_no_modifier_bound() {
-        let pressed = HashSet::new();
-        assert!(toggle_previews_should_fire(Some(88), None, 88, &pressed));
-        // A no-modifier binding fires even if some modifier happens to be
-        // held — same as the no-modifier cycle keys.
-        let shift_down: HashSet<u16> = [42].into_iter().collect();
-        assert!(toggle_previews_should_fire(Some(88), None, 88, &shift_down));
-    }
-
-    #[test]
-    fn toggle_requires_bound_modifier_to_be_held() {
-        // Bound as Shift(42)+88.
-        let none_held = HashSet::new();
-        assert!(!toggle_previews_should_fire(
-            Some(88),
-            Some(42),
-            88,
-            &none_held
-        ));
-        let shift_held: HashSet<u16> = [42].into_iter().collect();
-        assert!(toggle_previews_should_fire(
-            Some(88),
-            Some(42),
-            88,
-            &shift_held
-        ));
-    }
-
-    #[test]
-    fn toggle_never_fires_on_wrong_key_or_when_unbound() {
-        let shift_held: HashSet<u16> = [42].into_iter().collect();
-        assert!(!toggle_previews_should_fire(
-            Some(88),
-            Some(42),
-            99,
-            &shift_held
-        ));
-        assert!(!toggle_previews_should_fire(
-            None,
-            None,
-            88,
-            &HashSet::new()
-        ));
-    }
 }

--- a/src/keyboard_listener.rs
+++ b/src/keyboard_listener.rs
@@ -3,7 +3,7 @@
 //! same shape, same hot-reload contract, plus the character_hotkeys
 //! dispatch path that was missing from Linux entirely until now.
 
-use crate::config::{CharacterHotkey, Config, LiveSettings};
+use crate::config::{Config, Hotkey, LiveSettings, TriggerKind};
 use crate::cycle_state::CycleState;
 use crate::window_manager::WindowManager;
 use anyhow::Result;
@@ -23,7 +23,7 @@ pub struct KeyboardConfig {
     pub modifier_key: Option<u16>,
     pub keyboard_device_path: Option<String>,
     pub minimize_inactive: bool,
-    pub character_hotkeys: HashMap<String, CharacterHotkey>,
+    pub character_hotkeys: HashMap<String, Hotkey>,
     pub toggle_previews_key: Option<u16>,
     pub toggle_previews_modifier: Option<u16>,
 }
@@ -150,7 +150,7 @@ impl KeyboardListener {
             let modifier_codes: HashSet<u16> = std::iter::empty()
                 .chain(snap.modifier_key)
                 .chain(snap.toggle_previews_modifier)
-                .chain(snap.character_hotkeys.values().filter_map(|hk| hk.modifier))
+                .chain(snap.character_hotkeys.values().flat_map(|hk| hk.mods.iter().copied()))
                 .collect();
             // Forget pressed modifiers that are no longer modifiers in
             // any binding — otherwise a key the user un-bound stays
@@ -409,24 +409,18 @@ fn toggle_previews_should_fire(
 fn resolve_character_hotkey(
     code: u16,
     pressed_modifiers: &HashSet<u16>,
-    hotkeys: &HashMap<String, CharacterHotkey>,
+    hotkeys: &HashMap<String, Hotkey>,
 ) -> Option<String> {
-    // First pass: modifier-bearing bindings whose modifier is held.
-    let with_modifier = hotkeys.iter().find(|(_, hk)| {
-        hk.vk != 0
-            && hk.vk == code
-            && match hk.modifier {
-                Some(m) => pressed_modifiers.contains(&m),
-                None => false,
-            }
-    });
-    if let Some((name, _)) = with_modifier {
-        return Some(name.clone());
-    }
-    // Second pass: no-modifier bindings.
+    // Keyboard-triggered bindings only (mouse/wheel are handled by the
+    // mouse listener). Exact-set modifier match, so Ctrl+J never fires a
+    // bare-J bind. Among matches, the one needing the most modifiers wins,
+    // so Ctrl+J beats bare J when Ctrl is held.
     hotkeys
         .iter()
-        .find(|(_, hk)| hk.vk != 0 && hk.vk == code && hk.modifier.is_none())
+        .filter(|(_, hk)| {
+            hk.kind == TriggerKind::Key && hk.code == code && hk.mods_match(pressed_modifiers)
+        })
+        .max_by_key(|(_, hk)| hk.mods.len())
         .map(|(name, _)| name.clone())
 }
 

--- a/src/keyboard_listener.rs
+++ b/src/keyboard_listener.rs
@@ -62,8 +62,9 @@ impl KeyboardListener {
         wm: Arc<dyn WindowManager>,
         state: Arc<Mutex<CycleState>>,
         live: Arc<Mutex<LiveSettings>>,
+        held_modifiers: Arc<Mutex<HashSet<u16>>>,
     ) -> std::thread::JoinHandle<()> {
-        std::thread::spawn(move || Self::run_listener(shared, wm, state, live))
+        std::thread::spawn(move || Self::run_listener(shared, wm, state, live, held_modifiers))
     }
 
     fn run_listener(
@@ -71,6 +72,7 @@ impl KeyboardListener {
         wm: Arc<dyn WindowManager>,
         state: Arc<Mutex<CycleState>>,
         live: Arc<Mutex<LiveSettings>>,
+        held_modifiers: Arc<Mutex<HashSet<u16>>>,
     ) {
         let mut device: Option<Device> = None;
         let mut current_dev_path: Option<String> = None;
@@ -209,6 +211,8 @@ impl KeyboardListener {
                     } else {
                         pressed_modifiers.remove(&code);
                     }
+                    // Publish for the mouse listener's modifier-chord matching.
+                    *held_modifiers.lock().unwrap() = pressed_modifiers.clone();
                 }
 
                 // Only act on press / repeat.
@@ -428,33 +432,22 @@ fn resolve_character_hotkey(
 mod tests {
     use super::*;
 
-    fn hk(vk: u16, modifier: Option<u16>) -> CharacterHotkey {
-        CharacterHotkey { vk, modifier }
+    fn hk(code: u16, mods: Vec<u16>) -> Hotkey {
+        Hotkey::key_with_mods(code, mods)
     }
 
     #[test]
     fn unmatched_code_returns_none() {
         let mut hotkeys = HashMap::new();
-        hotkeys.insert("Alpha".to_string(), hk(0x70, None)); // F1
+        hotkeys.insert("Alpha".to_string(), hk(0x70, vec![])); // F1
         let pressed: HashSet<u16> = HashSet::new();
         assert_eq!(resolve_character_hotkey(0x71, &pressed, &hotkeys), None);
     }
 
     #[test]
-    fn placeholder_vk_zero_never_matches() {
-        // Panel writes vk=0 when the user picks a modifier before a
-        // key. Pressing any key (including code 0, theoretically)
-        // shouldn't dispatch a placeholder.
-        let mut hotkeys = HashMap::new();
-        hotkeys.insert("Alpha".to_string(), hk(0, Some(42)));
-        let pressed: HashSet<u16> = [42].into_iter().collect();
-        assert_eq!(resolve_character_hotkey(0, &pressed, &hotkeys), None);
-    }
-
-    #[test]
     fn no_modifier_binding_matches_when_no_modifier_held() {
         let mut hotkeys = HashMap::new();
-        hotkeys.insert("Alpha".to_string(), hk(0x70, None));
+        hotkeys.insert("Alpha".to_string(), hk(0x70, vec![]));
         let pressed: HashSet<u16> = HashSet::new();
         assert_eq!(
             resolve_character_hotkey(0x70, &pressed, &hotkeys),
@@ -465,7 +458,7 @@ mod tests {
     #[test]
     fn modifier_binding_requires_modifier_held() {
         let mut hotkeys = HashMap::new();
-        hotkeys.insert("Alpha".to_string(), hk(0x70, Some(0x10)));
+        hotkeys.insert("Alpha".to_string(), hk(0x70, vec![0x10]));
         // Press F1 without Shift held.
         assert_eq!(
             resolve_character_hotkey(0x70, &HashSet::new(), &hotkeys),
@@ -490,8 +483,8 @@ mod tests {
         // catches it in expectation rather than relying on a single
         // hash seed.
         let mut hotkeys = HashMap::new();
-        hotkeys.insert("AlphaWithShift".to_string(), hk(0x70, Some(0x10))); // Shift+F1
-        hotkeys.insert("BetaPlain".to_string(), hk(0x70, None)); // F1
+        hotkeys.insert("AlphaWithShift".to_string(), hk(0x70, vec![0x10])); // Shift+F1
+        hotkeys.insert("BetaPlain".to_string(), hk(0x70, vec![])); // F1
         let pressed: HashSet<u16> = [0x10].into_iter().collect();
         for _ in 0..32 {
             assert_eq!(
@@ -506,8 +499,8 @@ mod tests {
         // Same setup as above, but no modifier is held — should
         // resolve to the no-modifier binding.
         let mut hotkeys = HashMap::new();
-        hotkeys.insert("AlphaWithShift".to_string(), hk(0x70, Some(0x10)));
-        hotkeys.insert("BetaPlain".to_string(), hk(0x70, None));
+        hotkeys.insert("AlphaWithShift".to_string(), hk(0x70, vec![0x10]));
+        hotkeys.insert("BetaPlain".to_string(), hk(0x70, vec![]));
         let pressed: HashSet<u16> = HashSet::new();
         assert_eq!(
             resolve_character_hotkey(0x70, &pressed, &hotkeys),
@@ -521,8 +514,8 @@ mod tests {
         // Pressing F1 with Ctrl held should pick Beta. Pressing F1
         // with Shift held should pick Alpha.
         let mut hotkeys = HashMap::new();
-        hotkeys.insert("Alpha".to_string(), hk(0x70, Some(0x10)));
-        hotkeys.insert("Beta".to_string(), hk(0x70, Some(0x11)));
+        hotkeys.insert("Alpha".to_string(), hk(0x70, vec![0x10]));
+        hotkeys.insert("Beta".to_string(), hk(0x70, vec![0x11]));
 
         let shift_only: HashSet<u16> = [0x10].into_iter().collect();
         assert_eq!(
@@ -543,7 +536,7 @@ mod tests {
         // if no other binding exists for F1. The first-pass filter
         // requires the modifier to be in pressed_modifiers.
         let mut hotkeys = HashMap::new();
-        hotkeys.insert("Alpha".to_string(), hk(0x70, Some(0x10)));
+        hotkeys.insert("Alpha".to_string(), hk(0x70, vec![0x10]));
         assert_eq!(
             resolve_character_hotkey(0x70, &HashSet::new(), &hotkeys),
             None
@@ -588,7 +581,7 @@ mod tests {
         let mut with_char = idle_config();
         with_char
             .character_hotkeys
-            .insert("Alpha".to_string(), hk(0x70, None));
+            .insert("Alpha".to_string(), hk(0x70, vec![]));
         assert!(with_char.has_work());
     }
 

--- a/src/mouse_listener.rs
+++ b/src/mouse_listener.rs
@@ -16,7 +16,7 @@
 //! 200 ms poll timeout caps the worst-case latency for panel-driven
 //! changes to take effect.
 
-use crate::config::{Config, Hotkey, TriggerKind, WHEEL_DOWN, WHEEL_UP};
+use crate::config::{Config, Hotkey, LiveSettings, TriggerKind, WHEEL_DOWN, WHEEL_UP};
 use crate::cycle_state::CycleState;
 use crate::window_manager::WindowManager;
 use anyhow::Result;
@@ -39,6 +39,11 @@ pub struct MouseConfig {
     /// Per-character hotkeys whose trigger is a mouse button or wheel notch.
     /// (Key-triggered character hotkeys are handled by the keyboard listener.)
     pub character_hotkeys: HashMap<String, Hotkey>,
+    /// Cycle / toggle bindings — fired here when bound to a mouse button or
+    /// wheel notch (key triggers go through the keyboard listener).
+    pub forward_key: Hotkey,
+    pub backward_key: Hotkey,
+    pub toggle_previews_key: Hotkey,
 }
 
 impl MouseConfig {
@@ -51,15 +56,20 @@ impl MouseConfig {
             mouse_device_path: c.mouse_device_path.clone(),
             minimize_inactive: c.minimize_inactive,
             character_hotkeys: c.character_hotkeys.clone(),
+            forward_key: c.forward_key.clone(),
+            backward_key: c.backward_key.clone(),
+            toggle_previews_key: c.toggle_previews_key.clone(),
         }
     }
 
     /// Whether any character hotkey is bound to a mouse button or wheel —
     /// reason to keep the listener attached even when cycling is disabled.
     fn has_mouse_hotkeys(&self) -> bool {
-        self.character_hotkeys
-            .values()
-            .any(|hk| matches!(hk.kind, TriggerKind::Mouse | TriggerKind::Wheel))
+        let is_mouse = |hk: &Hotkey| matches!(hk.kind, TriggerKind::Mouse | TriggerKind::Wheel);
+        self.character_hotkeys.values().any(is_mouse)
+            || is_mouse(&self.forward_key)
+            || is_mouse(&self.backward_key)
+            || is_mouse(&self.toggle_previews_key)
     }
 }
 
@@ -83,8 +93,9 @@ impl MouseListener {
         wm: Arc<dyn WindowManager>,
         state: Arc<Mutex<CycleState>>,
         held_modifiers: Arc<Mutex<HashSet<u16>>>,
+        live: Arc<Mutex<LiveSettings>>,
     ) -> std::thread::JoinHandle<()> {
-        std::thread::spawn(move || Self::run_listener(shared, wm, state, held_modifiers))
+        std::thread::spawn(move || Self::run_listener(shared, wm, state, held_modifiers, live))
     }
 
     fn run_listener(
@@ -92,6 +103,7 @@ impl MouseListener {
         wm: Arc<dyn WindowManager>,
         state: Arc<Mutex<CycleState>>,
         held_modifiers: Arc<Mutex<HashSet<u16>>>,
+        live: Arc<Mutex<LiveSettings>>,
     ) {
         // Every side-button-capable device we're currently listening on.
         // Empty between scans (e.g. all devices unplugged) or while
@@ -264,26 +276,21 @@ impl MouseListener {
                                 }
                                 continue;
                             }
-                            // Per-character mouse-button hotkey.
+                            // Mouse-bound cycle / toggle / character hotkeys.
                             if recent(&last_cycle) {
                                 continue;
                             }
                             let held = held_modifiers.lock().unwrap().clone();
-                            if let Some(name) = Self::resolve_mouse_hotkey(
+                            if Self::dispatch_mouse_hotkey(
                                 TriggerKind::Mouse,
                                 code,
                                 &held,
-                                &snap.character_hotkeys,
+                                &snap,
+                                &wm,
+                                &state,
+                                &live,
                             ) {
                                 last_cycle = Some(Instant::now());
-                                if let Err(e) = Self::switch_to_character(
-                                    &name,
-                                    &wm,
-                                    &state,
-                                    snap.minimize_inactive,
-                                ) {
-                                    eprintln!("Failed to switch to {}: {}", name, e);
-                                }
                             }
                         }
                         InputEventKind::RelAxis(axis)
@@ -294,21 +301,16 @@ impl MouseListener {
                             }
                             let dir = if event.value() > 0 { WHEEL_UP } else { WHEEL_DOWN };
                             let held = held_modifiers.lock().unwrap().clone();
-                            if let Some(name) = Self::resolve_mouse_hotkey(
+                            if Self::dispatch_mouse_hotkey(
                                 TriggerKind::Wheel,
                                 dir,
                                 &held,
-                                &snap.character_hotkeys,
+                                &snap,
+                                &wm,
+                                &state,
+                                &live,
                             ) {
                                 last_cycle = Some(Instant::now());
-                                if let Err(e) = Self::switch_to_character(
-                                    &name,
-                                    &wm,
-                                    &state,
-                                    snap.minimize_inactive,
-                                ) {
-                                    eprintln!("Failed to switch to {}: {}", name, e);
-                                }
                             }
                         }
                         _ => {}
@@ -425,6 +427,49 @@ impl MouseListener {
         }
 
         Ok(found)
+    }
+
+    /// Dispatch a mouse/wheel trigger: toggle overlay, cycle backward/forward,
+    /// or activate a character — whichever binding matches the trigger + held
+    /// modifiers. Returns whether anything fired.
+    #[allow(clippy::too_many_arguments)]
+    fn dispatch_mouse_hotkey(
+        kind: TriggerKind,
+        code: u16,
+        held: &HashSet<u16>,
+        snap: &MouseConfig,
+        wm: &Arc<dyn WindowManager>,
+        state: &Arc<Mutex<CycleState>>,
+        live: &Arc<Mutex<LiveSettings>>,
+    ) -> bool {
+        if snap.toggle_previews_key.matches(kind, code, held) {
+            let mut live = live.lock().unwrap();
+            live.show_previews = !live.show_previews;
+            println!(
+                "Preview windows toggled {} via mouse hotkey",
+                if live.show_previews { "on" } else { "off" }
+            );
+            return true;
+        }
+        if snap.backward_key.matches(kind, code, held) {
+            if let Err(e) = Self::cycle_backward(wm, state, snap.minimize_inactive) {
+                eprintln!("Failed to cycle backward: {}", e);
+            }
+            return true;
+        }
+        if snap.forward_key.matches(kind, code, held) {
+            if let Err(e) = Self::cycle_forward(wm, state, snap.minimize_inactive) {
+                eprintln!("Failed to cycle forward: {}", e);
+            }
+            return true;
+        }
+        if let Some(name) = Self::resolve_mouse_hotkey(kind, code, held, &snap.character_hotkeys) {
+            if let Err(e) = Self::switch_to_character(&name, wm, state, snap.minimize_inactive) {
+                eprintln!("Failed to switch to {}: {}", name, e);
+            }
+            return true;
+        }
+        false
     }
 
     /// Activate a specific character (mouse/wheel hotkey target), mirroring

--- a/src/mouse_listener.rs
+++ b/src/mouse_listener.rs
@@ -16,14 +16,15 @@
 //! 200 ms poll timeout caps the worst-case latency for panel-driven
 //! changes to take effect.
 
-use crate::config::Config;
+use crate::config::{Config, Hotkey, TriggerKind, WHEEL_DOWN, WHEEL_UP};
 use crate::cycle_state::CycleState;
 use crate::window_manager::WindowManager;
 use anyhow::Result;
-use evdev::{Device, InputEventKind, Key};
+use evdev::{Device, InputEventKind, Key, RelativeAxisType};
 use nix::poll::{poll, PollFd, PollFlags, PollTimeout};
 use std::os::fd::{AsRawFd, BorrowedFd};
 use std::path::Path;
+use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
@@ -35,6 +36,9 @@ pub struct MouseConfig {
     pub mouse_device_name: Option<String>,
     pub mouse_device_path: Option<String>,
     pub minimize_inactive: bool,
+    /// Per-character hotkeys whose trigger is a mouse button or wheel notch.
+    /// (Key-triggered character hotkeys are handled by the keyboard listener.)
+    pub character_hotkeys: HashMap<String, Hotkey>,
 }
 
 impl MouseConfig {
@@ -46,7 +50,16 @@ impl MouseConfig {
             mouse_device_name: c.mouse_device_name.clone(),
             mouse_device_path: c.mouse_device_path.clone(),
             minimize_inactive: c.minimize_inactive,
+            character_hotkeys: c.character_hotkeys.clone(),
         }
+    }
+
+    /// Whether any character hotkey is bound to a mouse button or wheel —
+    /// reason to keep the listener attached even when cycling is disabled.
+    fn has_mouse_hotkeys(&self) -> bool {
+        self.character_hotkeys
+            .values()
+            .any(|hk| matches!(hk.kind, TriggerKind::Mouse | TriggerKind::Wheel))
     }
 }
 
@@ -69,14 +82,16 @@ impl MouseListener {
         shared: Arc<Mutex<MouseConfig>>,
         wm: Arc<dyn WindowManager>,
         state: Arc<Mutex<CycleState>>,
+        held_modifiers: Arc<Mutex<HashSet<u16>>>,
     ) -> std::thread::JoinHandle<()> {
-        std::thread::spawn(move || Self::run_listener(shared, wm, state))
+        std::thread::spawn(move || Self::run_listener(shared, wm, state, held_modifiers))
     }
 
     fn run_listener(
         shared: Arc<Mutex<MouseConfig>>,
         wm: Arc<dyn WindowManager>,
         state: Arc<Mutex<CycleState>>,
+        held_modifiers: Arc<Mutex<HashSet<u16>>>,
     ) {
         // Every side-button-capable device we're currently listening on.
         // Empty between scans (e.g. all devices unplugged) or while
@@ -94,9 +109,12 @@ impl MouseListener {
         loop {
             let snap = shared.lock().unwrap().clone();
 
-            if !snap.enable {
+            if !snap.enable && !snap.has_mouse_hotkeys() {
                 if !announced_idle {
-                    println!("Mouse listener idle (enable_mouse_buttons = false)");
+                    println!(
+                        "Mouse listener idle (enable_mouse_buttons = false, \
+                         no mouse/wheel character hotkeys)"
+                    );
                     announced_idle = true;
                     announced_listening = false;
                 }
@@ -221,29 +239,79 @@ impl MouseListener {
                     }
                 };
                 for event in events {
-                    if let InputEventKind::Key(key) = event.kind() {
-                        if event.value() != 1 {
-                            continue;
-                        }
-                        let code = key.code();
-                        let is_cycle = code == snap.forward_button || code == snap.backward_button;
-                        if is_cycle {
-                            // Drop a duplicate press echoed by a second device
-                            // node within the debounce window.
-                            let now = Instant::now();
-                            if last_cycle.is_some_and(|t| now.duration_since(t) < CYCLE_DEBOUNCE) {
+                    // De-dup presses echoed across a mouse's multiple event
+                    // nodes (see CYCLE_DEBOUNCE).
+                    let recent =
+                        |t: &Option<Instant>| t.is_some_and(|t| t.elapsed() < CYCLE_DEBOUNCE);
+                    match event.kind() {
+                        InputEventKind::Key(key) if event.value() == 1 => {
+                            let code = key.code();
+                            // Cycle side buttons (only when cycling is enabled).
+                            if snap.enable
+                                && (code == snap.forward_button || code == snap.backward_button)
+                            {
+                                if recent(&last_cycle) {
+                                    continue;
+                                }
+                                last_cycle = Some(Instant::now());
+                                let result = if code == snap.forward_button {
+                                    Self::cycle_forward(&wm, &state, snap.minimize_inactive)
+                                } else {
+                                    Self::cycle_backward(&wm, &state, snap.minimize_inactive)
+                                };
+                                if let Err(e) = result {
+                                    eprintln!("Failed to cycle: {}", e);
+                                }
                                 continue;
                             }
-                            last_cycle = Some(now);
-                            let result = if code == snap.forward_button {
-                                Self::cycle_forward(&wm, &state, snap.minimize_inactive)
-                            } else {
-                                Self::cycle_backward(&wm, &state, snap.minimize_inactive)
-                            };
-                            if let Err(e) = result {
-                                eprintln!("Failed to cycle: {}", e);
+                            // Per-character mouse-button hotkey.
+                            if recent(&last_cycle) {
+                                continue;
+                            }
+                            let held = held_modifiers.lock().unwrap().clone();
+                            if let Some(name) = Self::resolve_mouse_hotkey(
+                                TriggerKind::Mouse,
+                                code,
+                                &held,
+                                &snap.character_hotkeys,
+                            ) {
+                                last_cycle = Some(Instant::now());
+                                if let Err(e) = Self::switch_to_character(
+                                    &name,
+                                    &wm,
+                                    &state,
+                                    snap.minimize_inactive,
+                                ) {
+                                    eprintln!("Failed to switch to {}: {}", name, e);
+                                }
                             }
                         }
+                        InputEventKind::RelAxis(axis)
+                            if axis == RelativeAxisType::REL_WHEEL && event.value() != 0 =>
+                        {
+                            if recent(&last_cycle) {
+                                continue;
+                            }
+                            let dir = if event.value() > 0 { WHEEL_UP } else { WHEEL_DOWN };
+                            let held = held_modifiers.lock().unwrap().clone();
+                            if let Some(name) = Self::resolve_mouse_hotkey(
+                                TriggerKind::Wheel,
+                                dir,
+                                &held,
+                                &snap.character_hotkeys,
+                            ) {
+                                last_cycle = Some(Instant::now());
+                                if let Err(e) = Self::switch_to_character(
+                                    &name,
+                                    &wm,
+                                    &state,
+                                    snap.minimize_inactive,
+                                ) {
+                                    eprintln!("Failed to switch to {}: {}", name, e);
+                                }
+                            }
+                        }
+                        _ => {}
                     }
                 }
             }
@@ -357,6 +425,37 @@ impl MouseListener {
         }
 
         Ok(found)
+    }
+
+    /// Activate a specific character (mouse/wheel hotkey target), mirroring
+    /// the keyboard listener's switch path.
+    fn switch_to_character(
+        name: &str,
+        wm: &Arc<dyn WindowManager>,
+        state: &Arc<Mutex<CycleState>>,
+        minimize_inactive: bool,
+    ) -> Result<()> {
+        let mut state = state.lock().unwrap();
+        if let Ok(active) = wm.get_active_window() {
+            state.sync_with_active(active);
+        }
+        state.switch_to_character(name, &**wm, minimize_inactive)?;
+        Ok(())
+    }
+
+    /// Find the character hotkey matching this mouse/wheel trigger + held
+    /// modifiers (exact-set match; most-specific chord wins).
+    fn resolve_mouse_hotkey(
+        kind: TriggerKind,
+        code: u16,
+        held: &HashSet<u16>,
+        hotkeys: &HashMap<String, Hotkey>,
+    ) -> Option<String> {
+        hotkeys
+            .iter()
+            .filter(|(_, hk)| hk.kind == kind && hk.code == code && hk.mods_match(held))
+            .max_by_key(|(_, hk)| hk.mods.len())
+            .map(|(name, _)| name.clone())
     }
 
     fn cycle_forward(

--- a/src/windows_helpers.rs
+++ b/src/windows_helpers.rs
@@ -11,7 +11,7 @@
 //! still exercise every item below.
 #![allow(dead_code)]
 
-use crate::config::CharacterHotkey;
+use crate::config::{Hotkey, TriggerKind};
 use std::collections::HashMap;
 
 /// Direction of a cycle action. Used by `classify_xbutton` and by the
@@ -32,6 +32,7 @@ pub enum ModifierKind {
     Shift,
     Ctrl,
     Alt,
+    Win,
 }
 
 /// Map a Win32 VK code to the modifier it represents, or None if the
@@ -49,6 +50,7 @@ pub fn modifier_kind(vk: u16) -> Option<ModifierKind> {
         0x10 | 0xA0 | 0xA1 => Some(ModifierKind::Shift),
         0x11 | 0xA2 | 0xA3 => Some(ModifierKind::Ctrl),
         0x12 | 0xA4 | 0xA5 => Some(ModifierKind::Alt),
+        0x5B | 0x5C => Some(ModifierKind::Win),
         _ => None,
     }
 }
@@ -84,57 +86,45 @@ pub fn should_attach_thread_input(thread: u32, current: u32, exclude: &[u32]) ->
     thread != 0 && thread != current && !exclude.contains(&thread)
 }
 
+/// Map a Hotkey's modifier codes to RegisterHotKey modifier kinds, dropping
+/// any code that isn't a recognized modifier.
+fn mods_to_kinds(mods: &[u16]) -> Vec<ModifierKind> {
+    mods.iter().filter_map(|&m| modifier_kind(m)).collect()
+}
+
 /// A planned cycle (forward/backward) hotkey registration. Output of
 /// `plan_cycle_hotkeys`; the Windows consumer turns each entry into a
-/// `RegisterHotKey` call.
+/// `RegisterHotKey` call (its modifiers OR'd into the fsModifiers mask).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CycleHotkeyPlan {
     pub id: i32,
-    pub modifier: Option<ModifierKind>,
+    pub modifiers: Vec<ModifierKind>,
     pub vk: u16,
 }
 
-/// Plan which cycle hotkeys to register given the user's config.
-///
-/// Three relevant shapes:
-/// * Cycle hotkeys disabled → no entries.
-/// * Forward == Backward key, no modifier configured → forward only,
-///   no modifier (the backward registration is unreachable so we skip
-///   it; the modifier-bearing match in the modifier-key gating path
-///   below is what makes shift-tab work).
-/// * Forward == Backward key, modifier configured → forward (no mod)
-///   AND backward (with modifier).
-/// * Forward != Backward → both registered, neither with a modifier.
-///   The `modifier_key` setting is intentionally ignored in this case;
-///   it's only meaningful when forward/backward overlap.
+/// Plan which cycle hotkeys to register. Only key-triggered bindings are
+/// RegisterHotKey-able; mouse/wheel cycle bindings are dispatched by the
+/// low-level mouse hook, so they're skipped here. Each emitted plan carries
+/// the binding's full modifier chord (e.g. Shift+Tab for backward).
 pub fn plan_cycle_hotkeys(
     enable: bool,
-    forward_vk: u16,
-    backward_vk: u16,
-    modifier_vk: Option<u16>,
+    forward: &Hotkey,
+    backward: &Hotkey,
     forward_id: i32,
     backward_id: i32,
 ) -> Vec<CycleHotkeyPlan> {
     if !enable {
         return Vec::new();
     }
-    let mut plans = vec![CycleHotkeyPlan {
-        id: forward_id,
-        modifier: None,
-        vk: forward_vk,
-    }];
-    let same_key = forward_vk == backward_vk;
-    let backward_modifier = if same_key {
-        modifier_vk.and_then(modifier_kind)
-    } else {
-        None
-    };
-    if !same_key || backward_modifier.is_some() {
-        plans.push(CycleHotkeyPlan {
-            id: backward_id,
-            modifier: backward_modifier,
-            vk: backward_vk,
-        });
+    let mut plans = Vec::new();
+    for (hk, id) in [(forward, forward_id), (backward, backward_id)] {
+        if hk.kind == TriggerKind::Key && hk.code != 0 {
+            plans.push(CycleHotkeyPlan {
+                id,
+                modifiers: mods_to_kinds(&hk.mods),
+                vk: hk.code,
+            });
+        }
     }
     plans
 }
@@ -144,19 +134,16 @@ pub fn plan_cycle_hotkeys(
 pub struct CharacterHotkeyPlan {
     pub id: i32,
     pub character_name: String,
-    pub modifier: Option<ModifierKind>,
+    pub modifiers: Vec<ModifierKind>,
     pub vk: u16,
 }
 
-/// Plan per-character hotkey registrations in the user-configured
-/// character order. Skips characters that have no hotkey entry or
-/// whose VK is the placeholder 0 (the user picked a modifier but
-/// hasn't captured a key yet). IDs start at `base_id` and advance by
-/// one for every emitted plan — entries that are skipped don't burn an
-/// ID, so the ID sequence is dense.
+/// Plan per-character key hotkeys in the user-configured character order.
+/// Skips characters with no entry, unbound entries (key code 0), and
+/// mouse/wheel entries (the mouse hook handles those). IDs are dense.
 pub fn plan_character_hotkeys(
     characters: &[String],
-    character_hotkeys: &HashMap<String, CharacterHotkey>,
+    character_hotkeys: &HashMap<String, Hotkey>,
     base_id: i32,
 ) -> Vec<CharacterHotkeyPlan> {
     let mut out = Vec::new();
@@ -165,14 +152,14 @@ pub fn plan_character_hotkeys(
         let Some(hk) = character_hotkeys.get(name) else {
             continue;
         };
-        if hk.vk == 0 {
+        if hk.kind != TriggerKind::Key || hk.code == 0 {
             continue;
         }
         out.push(CharacterHotkeyPlan {
             id: next_id,
             character_name: name.clone(),
-            modifier: hk.modifier.and_then(modifier_kind),
-            vk: hk.vk,
+            modifiers: mods_to_kinds(&hk.mods),
+            vk: hk.code,
         });
         next_id += 1;
     }
@@ -262,78 +249,59 @@ mod tests {
 
     #[test]
     fn plan_cycle_hotkeys_returns_empty_when_disabled() {
-        let plans = plan_cycle_hotkeys(false, 0x70, 0x70, Some(0x10), 1, 2);
+        let plans = plan_cycle_hotkeys(false, &Hotkey::key(0x70), &Hotkey::key(0x71), 1, 2);
         assert!(plans.is_empty());
     }
 
     #[test]
-    fn plan_cycle_hotkeys_emits_forward_and_backward_when_keys_differ() {
-        let plans = plan_cycle_hotkeys(true, 0x70, 0x71, None, 1, 2);
+    fn plan_cycle_hotkeys_emits_both_when_key_bound() {
+        let plans = plan_cycle_hotkeys(true, &Hotkey::key(0x70), &Hotkey::key(0x71), 1, 2);
         assert_eq!(
             plans,
             vec![
-                CycleHotkeyPlan {
-                    id: 1,
-                    modifier: None,
-                    vk: 0x70
-                },
-                CycleHotkeyPlan {
-                    id: 2,
-                    modifier: None,
-                    vk: 0x71
-                },
+                CycleHotkeyPlan { id: 1, modifiers: vec![], vk: 0x70 },
+                CycleHotkeyPlan { id: 2, modifiers: vec![], vk: 0x71 },
             ]
         );
     }
 
     #[test]
-    fn plan_cycle_hotkeys_ignores_modifier_when_keys_differ() {
-        // The modifier_key field is only meaningful when forward and
-        // backward share a VK. With distinct keys, modifier must NOT
-        // apply to the backward entry — matches the original
-        // do_register_hotkeys behavior.
-        let plans = plan_cycle_hotkeys(true, 0x70, 0x71, Some(0x10), 1, 2);
-        assert_eq!(plans[1].modifier, None);
-    }
-
-    #[test]
-    fn plan_cycle_hotkeys_drops_backward_when_same_key_and_no_modifier() {
-        let plans = plan_cycle_hotkeys(true, 0x09, 0x09, None, 1, 2);
-        assert_eq!(plans.len(), 1);
-        assert_eq!(plans[0].id, 1);
-    }
-
-    #[test]
-    fn plan_cycle_hotkeys_uses_modifier_on_backward_when_keys_match() {
-        // The classic "Tab forward, Shift+Tab backward" config.
-        let plans = plan_cycle_hotkeys(true, 0x09, 0x09, Some(0x10), 1, 2);
+    fn plan_cycle_hotkeys_carries_backward_chord() {
+        // Classic Tab forward, Shift+Tab backward.
+        let plans = plan_cycle_hotkeys(
+            true,
+            &Hotkey::key(0x09),
+            &Hotkey::key_with_mods(0x09, vec![0x10]),
+            1,
+            2,
+        );
         assert_eq!(plans.len(), 2);
-        assert_eq!(plans[0].modifier, None);
-        assert_eq!(plans[1].modifier, Some(ModifierKind::Shift));
+        assert_eq!(plans[0].modifiers, vec![]);
+        assert_eq!(plans[1].modifiers, vec![ModifierKind::Shift]);
         assert_eq!(plans[1].vk, 0x09);
     }
 
     #[test]
-    fn plan_cycle_hotkeys_drops_backward_when_modifier_vk_isnt_a_modifier() {
-        // Defensive: if Config somehow stores a non-modifier VK as the
-        // modifier_key, the plan treats it as no modifier — same key +
-        // no modifier ⇒ skip backward.
-        let plans = plan_cycle_hotkeys(true, 0x09, 0x09, Some(0x41), 1, 2); // 'A'
-        assert_eq!(plans.len(), 1);
+    fn plan_cycle_hotkeys_skips_unbound_and_mouse_bindings() {
+        // Forward unbound; backward bound to a mouse button — neither is
+        // RegisterHotKey-able, so nothing is planned.
+        let mouse = Hotkey { mods: vec![], kind: TriggerKind::Mouse, code: 5 };
+        let plans = plan_cycle_hotkeys(true, &Hotkey::default(), &mouse, 1, 2);
+        assert!(plans.is_empty());
     }
 
     // ---- plan_character_hotkeys ----------------------------------------
 
-    fn hk(vk: u16, modifier: Option<u16>) -> CharacterHotkey {
-        CharacterHotkey { vk, modifier }
+    fn hk(vk: u16, mods: Vec<u16>) -> Hotkey {
+        Hotkey::key_with_mods(vk, mods)
     }
 
     #[test]
     fn plan_character_hotkeys_emits_entries_in_character_order() {
         let characters = vec!["Beta".to_string(), "Alpha".to_string()];
         let mut hotkeys = HashMap::new();
-        hotkeys.insert("Alpha".to_string(), hk(0x70, None));
-        hotkeys.insert("Beta".to_string(), hk(0x71, None));
+        hotkeys.insert("Alpha".to_string(), hk(0x70, vec![]));
+        hotkeys.insert("Beta".to_string(), hk(0x71, vec![]));
         let plans = plan_character_hotkeys(&characters, &hotkeys, 2000);
         assert_eq!(plans.len(), 2);
         assert_eq!(plans[0].character_name, "Beta");
@@ -346,38 +314,50 @@ mod tests {
     fn plan_character_hotkeys_skips_characters_without_a_binding() {
         let characters = vec!["Alpha".to_string(), "Beta".to_string()];
         let mut hotkeys = HashMap::new();
-        hotkeys.insert("Beta".to_string(), hk(0x71, None));
+        hotkeys.insert("Beta".to_string(), hk(0x71, vec![]));
         let plans = plan_character_hotkeys(&characters, &hotkeys, 2000);
         assert_eq!(plans.len(), 1);
         assert_eq!(plans[0].character_name, "Beta");
-        // No ID burned for the skipped character.
         assert_eq!(plans[0].id, 2000);
     }
 
     #[test]
-    fn plan_character_hotkeys_skips_placeholder_vk_zero() {
+    fn plan_character_hotkeys_skips_unbound_key() {
         let characters = vec!["Alpha".to_string()];
         let mut hotkeys = HashMap::new();
-        hotkeys.insert("Alpha".to_string(), hk(0, Some(0x10)));
+        hotkeys.insert("Alpha".to_string(), hk(0, vec![0x10]));
         let plans = plan_character_hotkeys(&characters, &hotkeys, 2000);
         assert!(plans.is_empty());
     }
 
     #[test]
-    fn plan_character_hotkeys_translates_modifier_vk_into_modifier_kind() {
+    fn plan_character_hotkeys_skips_mouse_bindings() {
         let characters = vec!["Alpha".to_string()];
         let mut hotkeys = HashMap::new();
-        hotkeys.insert("Alpha".to_string(), hk(0x70, Some(0x11))); // Ctrl
+        hotkeys.insert(
+            "Alpha".to_string(),
+            Hotkey { mods: vec![], kind: TriggerKind::Mouse, code: 5 },
+        );
         let plans = plan_character_hotkeys(&characters, &hotkeys, 2000);
-        assert_eq!(plans[0].modifier, Some(ModifierKind::Ctrl));
+        assert!(plans.is_empty());
     }
 
     #[test]
-    fn plan_character_hotkeys_treats_non_modifier_vk_as_no_modifier() {
+    fn plan_character_hotkeys_translates_modifier_chord() {
         let characters = vec!["Alpha".to_string()];
         let mut hotkeys = HashMap::new();
-        hotkeys.insert("Alpha".to_string(), hk(0x70, Some(0x41))); // 'A' isn't a modifier
+        hotkeys.insert("Alpha".to_string(), hk(0x70, vec![0x11, 0x10])); // Ctrl+Shift
         let plans = plan_character_hotkeys(&characters, &hotkeys, 2000);
-        assert_eq!(plans[0].modifier, None);
+        // key_with_mods sorts by code: 0x10 (Shift) before 0x11 (Ctrl).
+        assert_eq!(plans[0].modifiers, vec![ModifierKind::Shift, ModifierKind::Ctrl]);
+    }
+
+    #[test]
+    fn plan_character_hotkeys_drops_non_modifier_codes() {
+        let characters = vec!["Alpha".to_string()];
+        let mut hotkeys = HashMap::new();
+        hotkeys.insert("Alpha".to_string(), hk(0x70, vec![0x41])); // 'A' isn't a modifier
+        let plans = plan_character_hotkeys(&characters, &hotkeys, 2000);
+        assert_eq!(plans[0].modifiers, vec![]);
     }
 }

--- a/src/windows_helpers.rs
+++ b/src/windows_helpers.rs
@@ -12,7 +12,7 @@
 #![allow(dead_code)]
 
 use crate::config::{Hotkey, TriggerKind};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 /// Direction of a cycle action. Used by `classify_xbutton` and by the
 /// Windows input listener's internal message dispatch. Cross-platform
@@ -166,9 +166,58 @@ pub fn plan_character_hotkeys(
     out
 }
 
+/// What a mouse-button / wheel trigger maps to, resolved from the configured
+/// bindings. `SwitchCharacter` carries the index into the `characters` slice
+/// so the (Win32-side) caller can pass it through a thread message without
+/// allocating.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MouseHotkeyAction {
+    CycleForward,
+    CycleBackward,
+    ToggleOverlay,
+    SwitchCharacter(usize),
+}
+
+/// Resolve a mouse/wheel trigger (button or wheel code + held modifiers) to an
+/// action, mirroring the Linux mouse listener's priority: toggle, then
+/// backward, then forward, then per-character (most-specific chord wins). Only
+/// `TriggerKind::Mouse` / `TriggerKind::Wheel` bindings can match here; key
+/// bindings go through RegisterHotKey.
+#[allow(clippy::too_many_arguments)]
+pub fn resolve_mouse_action(
+    kind: TriggerKind,
+    code: u16,
+    held: &HashSet<u16>,
+    forward: &Hotkey,
+    backward: &Hotkey,
+    toggle: &Hotkey,
+    characters: &[String],
+    character_hotkeys: &HashMap<String, Hotkey>,
+) -> Option<MouseHotkeyAction> {
+    if toggle.matches(kind, code, held) {
+        return Some(MouseHotkeyAction::ToggleOverlay);
+    }
+    if backward.matches(kind, code, held) {
+        return Some(MouseHotkeyAction::CycleBackward);
+    }
+    if forward.matches(kind, code, held) {
+        return Some(MouseHotkeyAction::CycleForward);
+    }
+    let mut best: Option<(usize, usize)> = None; // (character index, mods len)
+    for (i, name) in characters.iter().enumerate() {
+        if let Some(hk) = character_hotkeys.get(name) {
+            if hk.matches(kind, code, held) && best.is_none_or(|(_, b)| hk.mods.len() > b) {
+                best = Some((i, hk.mods.len()));
+            }
+        }
+    }
+    best.map(|(i, _)| MouseHotkeyAction::SwitchCharacter(i))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::WHEEL_UP;
 
     // ---- modifier_kind --------------------------------------------------
 
@@ -359,5 +408,74 @@ mod tests {
         hotkeys.insert("Alpha".to_string(), hk(0x70, vec![0x41])); // 'A' isn't a modifier
         let plans = plan_character_hotkeys(&characters, &hotkeys, 2000);
         assert_eq!(plans[0].modifiers, vec![]);
+    }
+
+    // ---- resolve_mouse_action ------------------------------------------
+
+    fn mouse(code: u16, mods: Vec<u16>) -> Hotkey {
+        Hotkey { mods, kind: TriggerKind::Mouse, code }
+    }
+
+    #[test]
+    fn resolve_mouse_action_prioritises_toggle_then_cycle() {
+        let none = HashSet::new();
+        let fwd = mouse(1, vec![]);
+        let back = mouse(2, vec![]);
+        let toggle = mouse(3, vec![]);
+        let chars: Vec<String> = vec![];
+        let map = HashMap::new();
+        assert_eq!(
+            resolve_mouse_action(TriggerKind::Mouse, 3, &none, &fwd, &back, &toggle, &chars, &map),
+            Some(MouseHotkeyAction::ToggleOverlay)
+        );
+        assert_eq!(
+            resolve_mouse_action(TriggerKind::Mouse, 2, &none, &fwd, &back, &toggle, &chars, &map),
+            Some(MouseHotkeyAction::CycleBackward)
+        );
+        assert_eq!(
+            resolve_mouse_action(TriggerKind::Mouse, 1, &none, &fwd, &back, &toggle, &chars, &map),
+            Some(MouseHotkeyAction::CycleForward)
+        );
+    }
+
+    #[test]
+    fn resolve_mouse_action_matches_wheel_and_character_index() {
+        let none = HashSet::new();
+        let unbound = Hotkey::default();
+        let chars = vec!["Alpha".to_string(), "Bravo".to_string()];
+        let mut map = HashMap::new();
+        map.insert("Bravo".to_string(), Hotkey { mods: vec![], kind: TriggerKind::Wheel, code: WHEEL_UP });
+        assert_eq!(
+            resolve_mouse_action(
+                TriggerKind::Wheel, WHEEL_UP, &none, &unbound, &unbound, &unbound, &chars, &map,
+            ),
+            Some(MouseHotkeyAction::SwitchCharacter(1))
+        );
+        // Wrong kind (a key) never matches a mouse/wheel resolve.
+        assert_eq!(
+            resolve_mouse_action(
+                TriggerKind::Key, WHEEL_UP, &none, &unbound, &unbound, &unbound, &chars, &map,
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn resolve_mouse_action_requires_modifier_chord() {
+        let unbound = Hotkey::default();
+        let chars: Vec<String> = vec![];
+        let map = HashMap::new();
+        // Ctrl(0x11)+Mouse4 backward.
+        let back = mouse(4, vec![0x11]);
+        let none = HashSet::new();
+        assert_eq!(
+            resolve_mouse_action(TriggerKind::Mouse, 4, &none, &unbound, &back, &unbound, &chars, &map),
+            None
+        );
+        let ctrl: HashSet<u16> = [0x11].into_iter().collect();
+        assert_eq!(
+            resolve_mouse_action(TriggerKind::Mouse, 4, &ctrl, &unbound, &back, &unbound, &chars, &map),
+            Some(MouseHotkeyAction::CycleBackward)
+        );
     }
 }

--- a/src/windows_input.rs
+++ b/src/windows_input.rs
@@ -1,4 +1,4 @@
-use crate::config::{Config, LiveSettings};
+use crate::config::{Config, LiveSettings, TriggerKind};
 use crate::cycle_state::CycleState;
 use crate::window_manager::WindowManager;
 use crate::windows_helpers::{
@@ -14,7 +14,7 @@ use windows::Win32::Foundation::{HINSTANCE, LPARAM, LRESULT, WPARAM};
 use windows::Win32::System::LibraryLoader::GetModuleHandleW;
 use windows::Win32::System::Threading::GetCurrentThreadId;
 use windows::Win32::UI::Input::KeyboardAndMouse::{
-    RegisterHotKey, UnregisterHotKey, HOT_KEY_MODIFIERS, MOD_ALT, MOD_CONTROL, MOD_SHIFT,
+    RegisterHotKey, UnregisterHotKey, HOT_KEY_MODIFIERS, MOD_ALT, MOD_CONTROL, MOD_SHIFT, MOD_WIN,
 };
 use windows::Win32::UI::WindowsAndMessaging::{
     CallNextHookEx, GetMessageW, PostThreadMessageW, SetWindowsHookExW, HHOOK, MSG, MSLLHOOKSTRUCT,
@@ -177,13 +177,17 @@ fn debug_input(args: std::fmt::Arguments) {
 /// HOT_KEY_MODIFIERS bitmask RegisterHotKey expects. The planner is
 /// kept platform-independent (see `windows_helpers`) so this thin
 /// adapter is the only place that knows about MOD_SHIFT/etc.
-fn modifier_to_winapi(kind: Option<ModifierKind>) -> HOT_KEY_MODIFIERS {
-    match kind {
-        Some(ModifierKind::Shift) => MOD_SHIFT,
-        Some(ModifierKind::Ctrl) => MOD_CONTROL,
-        Some(ModifierKind::Alt) => MOD_ALT,
-        None => HOT_KEY_MODIFIERS(0),
+fn modifier_to_winapi(kinds: &[ModifierKind]) -> HOT_KEY_MODIFIERS {
+    let mut bits = 0u32;
+    for k in kinds {
+        bits |= match k {
+            ModifierKind::Shift => MOD_SHIFT.0,
+            ModifierKind::Ctrl => MOD_CONTROL.0,
+            ModifierKind::Alt => MOD_ALT.0,
+            ModifierKind::Win => MOD_WIN.0,
+        };
     }
+    HOT_KEY_MODIFIERS(bits)
 }
 
 /// Spawn the Windows input listener thread. The thread installs a low-level
@@ -351,30 +355,31 @@ fn run_listener(
 unsafe fn do_register_hotkeys(config: &Config) {
     for plan in plan_cycle_hotkeys(
         config.enable_keyboard_buttons,
-        config.forward_key,
-        config.backward_key,
-        config.modifier_key,
+        &config.forward_key,
+        &config.backward_key,
         HOTKEY_FORWARD_ID,
         HOTKEY_BACKWARD_ID,
     ) {
         let _ = RegisterHotKey(
             None,
             plan.id,
-            modifier_to_winapi(plan.modifier),
+            modifier_to_winapi(&plan.modifiers),
             plan.vk as u32,
         );
     }
 
-    // Preview-visibility toggle, with optional modifier. Independent of
-    // enable_keyboard_buttons — it flips show_previews regardless of
-    // whether cycling is on.
-    if let Some(vk) = config.toggle_previews_key {
-        let modifier = config.toggle_previews_modifier.and_then(modifier_kind);
+    // Preview-visibility toggle. Only key-triggered toggles are
+    // RegisterHotKey-able (a mouse/wheel toggle would run through the mouse
+    // hook). Independent of enable_keyboard_buttons.
+    let toggle = &config.toggle_previews_key;
+    if toggle.kind == TriggerKind::Key && toggle.code != 0 {
+        let mods: Vec<ModifierKind> =
+            toggle.mods.iter().filter_map(|&m| modifier_kind(m)).collect();
         let _ = RegisterHotKey(
             None,
             HOTKEY_TOGGLE_PREVIEWS_ID,
-            modifier_to_winapi(modifier),
-            vk as u32,
+            modifier_to_winapi(&mods),
+            toggle.code as u32,
         );
     }
 
@@ -385,7 +390,7 @@ unsafe fn do_register_hotkeys(config: &Config) {
         &config.character_hotkeys,
         HOTKEY_CHARACTER_BASE,
     ) {
-        let modifier = modifier_to_winapi(plan.modifier);
+        let modifier = modifier_to_winapi(&plan.modifiers);
         if RegisterHotKey(None, plan.id, modifier, plan.vk as u32).is_ok() {
             lookup.insert(plan.id, plan.character_name);
         } else {

--- a/src/windows_input.rs
+++ b/src/windows_input.rs
@@ -1,12 +1,12 @@
-use crate::config::{Config, LiveSettings, TriggerKind};
+use crate::config::{Config, Hotkey, LiveSettings, TriggerKind, WHEEL_DOWN, WHEEL_UP};
 use crate::cycle_state::CycleState;
 use crate::window_manager::WindowManager;
 use crate::windows_helpers::{
-    classify_xbutton, modifier_kind, plan_character_hotkeys, plan_cycle_hotkeys, CycleDirection,
-    ModifierKind,
+    classify_xbutton, modifier_kind, plan_character_hotkeys, plan_cycle_hotkeys, resolve_mouse_action,
+    CycleDirection, ModifierKind, MouseHotkeyAction,
 };
 use anyhow::{Context, Result};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
 use std::thread::JoinHandle;
@@ -14,11 +14,12 @@ use windows::Win32::Foundation::{HINSTANCE, LPARAM, LRESULT, WPARAM};
 use windows::Win32::System::LibraryLoader::GetModuleHandleW;
 use windows::Win32::System::Threading::GetCurrentThreadId;
 use windows::Win32::UI::Input::KeyboardAndMouse::{
-    RegisterHotKey, UnregisterHotKey, HOT_KEY_MODIFIERS, MOD_ALT, MOD_CONTROL, MOD_SHIFT, MOD_WIN,
+    GetAsyncKeyState, RegisterHotKey, UnregisterHotKey, HOT_KEY_MODIFIERS, MOD_ALT, MOD_CONTROL,
+    MOD_SHIFT, MOD_WIN,
 };
 use windows::Win32::UI::WindowsAndMessaging::{
     CallNextHookEx, GetMessageW, PostThreadMessageW, SetWindowsHookExW, HHOOK, MSG, MSLLHOOKSTRUCT,
-    WH_MOUSE_LL, WM_HOTKEY, WM_USER, WM_XBUTTONDOWN,
+    WH_MOUSE_LL, WM_HOTKEY, WM_MOUSEWHEEL, WM_USER, WM_XBUTTONDOWN,
 };
 
 const HOTKEY_FORWARD_ID: i32 = 1001;
@@ -40,10 +41,41 @@ fn character_lookup() -> &'static Mutex<HashMap<i32, String>> {
     CHARACTER_HOTKEY_LOOKUP.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
+/// Mouse/wheel-relevant bindings the low-level hook needs to match a click or
+/// wheel notch. Refreshed on every (re)register so panel edits take effect
+/// without a daemon restart. The hook callback can't capture, so this lives
+/// in a global.
+struct MouseHotkeyState {
+    forward: Hotkey,
+    backward: Hotkey,
+    toggle: Hotkey,
+    characters: Vec<String>,
+    character_hotkeys: HashMap<String, Hotkey>,
+}
+
+static MOUSE_HOTKEYS: OnceLock<Mutex<MouseHotkeyState>> = OnceLock::new();
+
+fn mouse_hotkeys() -> &'static Mutex<MouseHotkeyState> {
+    MOUSE_HOTKEYS.get_or_init(|| {
+        Mutex::new(MouseHotkeyState {
+            forward: Hotkey::default(),
+            backward: Hotkey::default(),
+            toggle: Hotkey::default(),
+            characters: Vec::new(),
+            character_hotkeys: HashMap::new(),
+        })
+    })
+}
+
 const WM_USER_FORWARD: u32 = WM_USER + 1;
 const WM_USER_BACKWARD: u32 = WM_USER + 2;
 const WM_USER_PAUSE: u32 = WM_USER + 3;
 const WM_USER_RESUME: u32 = WM_USER + 4;
+/// Posted by the mouse hook when a mouse/wheel binding maps to overlay-toggle.
+const WM_USER_TOGGLE: u32 = WM_USER + 5;
+/// Posted by the mouse hook for a mouse/wheel per-character switch; wParam is
+/// the character's index into the config order.
+const WM_USER_CHARACTER: u32 = WM_USER + 6;
 
 /// Thread ID of the running input listener, exposed so the config
 /// panel can PostThreadMessage pause/resume signals when the user is
@@ -111,53 +143,96 @@ struct HookContext {
 static HOOK_CTX: OnceLock<HookContext> = OnceLock::new();
 
 unsafe extern "system" fn mouse_hook_proc(code: i32, wparam: WPARAM, lparam: LPARAM) -> LRESULT {
-    if code >= 0 && wparam.0 as u32 == WM_XBUTTONDOWN {
+    if code >= 0 {
+        let message = wparam.0 as u32;
         let info = &*(lparam.0 as *const MSLLHOOKSTRUCT);
-        // High word of mouseData identifies the X button: 1 = XBUTTON1 (back),
-        // 2 = XBUTTON2 (forward).
-        let xbutton = ((info.mouseData >> 16) & 0xFFFF) as u16;
-        debug_input(format_args!(
-            "mouse_hook_proc: WM_XBUTTONDOWN raw={:#010x} xbutton={} flags={:#x}",
-            info.mouseData, xbutton, info.flags
-        ));
-
-        // Pass-through when cycling is disabled (user set
-        // enable_mouse_buttons = false in config).
-        if !MOUSE_CYCLE_ENABLED.load(Ordering::Acquire) {
-            debug_input(format_args!(
-                "mouse_hook_proc: MOUSE_CYCLE_ENABLED=false, pass-through"
-            ));
-            return CallNextHookEx(None, code, wparam, lparam);
-        }
-
-        if let Some(ctx) = HOOK_CTX.get() {
-            let post =
-                classify_xbutton(xbutton, ctx.forward_button, ctx.backward_button).map(|dir| {
-                    match dir {
-                        CycleDirection::Forward => WM_USER_FORWARD,
-                        CycleDirection::Backward => WM_USER_BACKWARD,
-                    }
-                });
-            debug_input(format_args!(
-                "mouse_hook_proc: classify xbutton={} fwd={} back={} -> post={:?}",
-                xbutton, ctx.forward_button, ctx.backward_button, post
-            ));
-
-            if let Some(msg) = post {
-                // PostThreadMessageW returns Err if the thread queue is
-                // unavailable (e.g. listener has exited). Best-effort.
-                let result = PostThreadMessageW(ctx.listener_thread_id, msg, WPARAM(0), LPARAM(0));
-                debug_input(format_args!(
-                    "mouse_hook_proc: PostThreadMessageW tid={} msg={:#x} result={:?}",
-                    ctx.listener_thread_id, msg, result
-                ));
+        // Map the raw event to a (kind, code) trigger: x-buttons → Mouse
+        // (1 = XBUTTON1, 2 = XBUTTON2); wheel notches → Wheel up/down.
+        let trigger = match message {
+            WM_XBUTTONDOWN => Some((TriggerKind::Mouse, ((info.mouseData >> 16) & 0xFFFF) as u16)),
+            WM_MOUSEWHEEL => {
+                let delta = ((info.mouseData >> 16) & 0xFFFF) as i16;
+                if delta > 0 {
+                    Some((TriggerKind::Wheel, WHEEL_UP))
+                } else if delta < 0 {
+                    Some((TriggerKind::Wheel, WHEEL_DOWN))
+                } else {
+                    None
+                }
             }
-        } else {
-            debug_input(format_args!("mouse_hook_proc: HOOK_CTX unset"));
+            _ => None,
+        };
+
+        if let (Some((kind, tcode)), Some(ctx)) = (trigger, HOOK_CTX.get()) {
+            let held = held_modifiers();
+            let action = {
+                let st = mouse_hotkeys().lock().unwrap();
+                resolve_mouse_action(
+                    kind,
+                    tcode,
+                    &held,
+                    &st.forward,
+                    &st.backward,
+                    &st.toggle,
+                    &st.characters,
+                    &st.character_hotkeys,
+                )
+            };
+            debug_input(format_args!(
+                "mouse_hook_proc: kind={:?} code={} -> {:?}",
+                kind, tcode, action
+            ));
+            let post: Option<(u32, usize)> = match action {
+                Some(MouseHotkeyAction::CycleForward) => Some((WM_USER_FORWARD, 0)),
+                Some(MouseHotkeyAction::CycleBackward) => Some((WM_USER_BACKWARD, 0)),
+                Some(MouseHotkeyAction::ToggleOverlay) => Some((WM_USER_TOGGLE, 0)),
+                Some(MouseHotkeyAction::SwitchCharacter(i)) => Some((WM_USER_CHARACTER, i)),
+                // No explicit binding: fall back to the legacy side-button
+                // cycle (forward_button/backward_button), gated by the
+                // enable_mouse_buttons toggle.
+                None if message == WM_XBUTTONDOWN
+                    && MOUSE_CYCLE_ENABLED.load(Ordering::Acquire) =>
+                {
+                    classify_xbutton(tcode, ctx.forward_button, ctx.backward_button).map(|dir| {
+                        let m = match dir {
+                            CycleDirection::Forward => WM_USER_FORWARD,
+                            CycleDirection::Backward => WM_USER_BACKWARD,
+                        };
+                        (m, 0usize)
+                    })
+                }
+                None => None,
+            };
+            if let Some((m, w)) = post {
+                let _ = PostThreadMessageW(ctx.listener_thread_id, m, WPARAM(w), LPARAM(0));
+            }
         }
     }
     CallNextHookEx(None, code, wparam, lparam)
 }
+
+/// Snapshot the currently-held modifier keys as the same VK codes the panel
+/// records, so a mouse/wheel chord captured in the panel matches at runtime.
+fn held_modifiers() -> HashSet<u16> {
+    let mut held = HashSet::new();
+    // A closure does not inherit the unsafe context of an enclosing unsafe
+    // fn, so the FFI call needs its own unsafe block regardless.
+    let down = |vk: i32| (unsafe { GetAsyncKeyState(vk) } as u16 & 0x8000) != 0;
+    if down(0x11) {
+        held.insert(0x11); // VK_CONTROL
+    }
+    if down(0x10) {
+        held.insert(0x10); // VK_SHIFT
+    }
+    if down(0x12) {
+        held.insert(0x12); // VK_MENU (Alt)
+    }
+    if down(0x5B) {
+        held.insert(0x5B); // VK_LWIN
+    }
+    held
+}
+
 
 /// Diagnostic logging gated by `NICOTINE_DEBUG_INPUT`. Used by
 /// integration tests to instrument the mouse-hook -> listener ->
@@ -306,7 +381,9 @@ fn run_listener(
         // Preview-visibility toggle hotkey? Flip the shared LiveSettings
         // flag the preview manager watches; it shows/hides on the next
         // reconcile tick, same as the panel checkbox.
-        if msg.message == WM_HOTKEY && msg.wParam.0 as i32 == HOTKEY_TOGGLE_PREVIEWS_ID {
+        if msg.message == WM_USER_TOGGLE
+            || (msg.message == WM_HOTKEY && msg.wParam.0 as i32 == HOTKEY_TOGGLE_PREVIEWS_ID)
+        {
             let mut live_guard = live.lock().unwrap();
             live_guard.show_previews = !live_guard.show_previews;
             println!(
@@ -317,6 +394,24 @@ fn run_listener(
                     "off"
                 }
             );
+            continue;
+        }
+
+        // Mouse/wheel-bound character switch (hook posts the character's
+        // config index in wParam).
+        if msg.message == WM_USER_CHARACTER {
+            let idx = msg.wParam.0;
+            let name = mouse_hotkeys().lock().unwrap().characters.get(idx).cloned();
+            if let Some(name) = name {
+                let minimize_inactive = minimize_inactive_lookup();
+                let mut state_guard = state.lock().unwrap();
+                if let Ok(active) = wm.get_active_window() {
+                    state_guard.sync_with_active(active);
+                }
+                if let Err(e) = state_guard.switch_to_character(&name, &*wm, minimize_inactive) {
+                    eprintln!("Character switch failed: {}", e);
+                }
+            }
             continue;
         }
 
@@ -400,6 +495,15 @@ unsafe fn do_register_hotkeys(config: &Config) {
             );
         }
     }
+
+    // Refresh the mouse hook's view of the mouse/wheel-triggered bindings.
+    *mouse_hotkeys().lock().unwrap() = MouseHotkeyState {
+        forward: config.forward_key.clone(),
+        backward: config.backward_key.clone(),
+        toggle: config.toggle_previews_key.clone(),
+        characters: config.characters.clone(),
+        character_hotkeys: config.character_hotkeys.clone(),
+    };
 }
 
 fn register_hotkeys(config: &Config) {


### PR DESCRIPTION
Reworks how every keybinding is set and what a binding can be — one widget, used at every bind site.

**Input widget**
- Replaces the per-site key field + modifier dropdown with a single keybind chip used everywhere: per-character, forward, backward, and toggle-overlay. Left-click to record the next input, right-click to clear, with a tooltip.
- A binding can now be a modifier chord (e.g. `Ctrl+Shift+J`), a mouse button, or a wheel notch — not just a bare key.
- The per-character row collapses from a two-row (name + modifier dropdown + key) block to one compact line.

**Model**
- New unified `Hotkey` type (modifier set + key/mouse/wheel trigger) replaces the old `CharacterHotkey` and the separate `modifier_key` / `toggle_previews_modifier` fields. Backward is now just its own chord (default `Shift`+forward) instead of a shared-key + modifier trick.

**Linux runtime**
- Keyboard listener matches chords with exact-set modifier comparison.
- Mouse listener fires mouse-button and wheel bindings, including wheel-to-cycle, and shares a held-modifier set with the keyboard listener so mouse+modifier chords resolve across the two evdev devices.

**Windows runtime**
- Keyboard bindings: `RegisterHotKey` gets the full chord via an OR'd `fsModifiers` mask (adds `Win`); toggle-overlay registers from its `Hotkey`.
- Mouse/wheel bindings: the low-level mouse hook resolves mouse-button and wheel triggers (with `GetAsyncKeyState` modifiers) against the configured cycle / toggle / per-character bindings and posts them to the listener; bindings refresh on every re-register so panel edits apply live. The legacy `enable_mouse_buttons` XBUTTON cycle remains as a fallback.
- The trigger-matching logic lives in `windows_helpers` and is unit-tested on Linux.

**Config compatibility**
- `forward_key` / `backward_key` / `toggle_previews_key` and `[character_hotkeys."Name"]` are now `Hotkey` tables (`mods`, `kind`, `code`). Pre-upgrade configs that stored a bare integer key code still load (the integer becomes a plain-key binding); the removed `modifier_key` / `toggle_previews_modifier` keys are ignored.

**README** updated for the new binding model.

**Note**
- Built and tested on Linux. The Windows cfg path is migrated to pattern and reviewed by inspection, but wasn't compiled in this environment (no MinGW to cross-build a C dependency), so it should be smoke-tested on Windows. The pure trigger-matching/planning logic it relies on is covered by tests that do run.
